### PR TITLE
Use browser locale for initial defaults

### DIFF
--- a/src/lib/defaultAppLocale.test.ts
+++ b/src/lib/defaultAppLocale.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { selectDefaultAppLocale } from './defaultAppLocale'
+
+describe('selectDefaultAppLocale', () => {
+  it('uses Spanish for Spanish browser locales', () => {
+    expect(selectDefaultAppLocale('es-ES')).toBe('es')
+  })
+
+  it('uses English for English browser locales', () => {
+    expect(selectDefaultAppLocale('en-US')).toBe('en')
+  })
+
+  it('falls back to English for unsupported browser locales', () => {
+    expect(selectDefaultAppLocale('fr-FR')).toBe('en')
+  })
+})

--- a/src/lib/defaultAppLocale.ts
+++ b/src/lib/defaultAppLocale.ts
@@ -1,0 +1,21 @@
+export type AppLocale = 'en' | 'es'
+
+export const APP_LOCALE_STORAGE_KEY = 'locale'
+
+export function getStoredAppLocale(): AppLocale | null {
+  const locale = localStorage.getItem(APP_LOCALE_STORAGE_KEY)
+
+  return isAppLocale(locale) ? locale : null
+}
+
+export function getBrowserLocale(): string {
+  return navigator.languages?.[0] ?? navigator.language ?? ''
+}
+
+export function selectDefaultAppLocale(browserLocale: string): AppLocale {
+  return browserLocale.toLowerCase().startsWith('es') ? 'es' : 'en'
+}
+
+function isAppLocale(locale: string | null): locale is AppLocale {
+  return locale === 'en' || locale === 'es'
+}

--- a/src/lib/defaultBibleVersion.test.ts
+++ b/src/lib/defaultBibleVersion.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { selectDefaultBibleVersionId } from './defaultBibleVersion'
+import type { ApiVersion } from './bibleApi'
+
+const versions: ApiVersion[] = [
+  { id: 1, abbreviation: 'KJV', name: 'King James Version', language: 'en' },
+  { id: 2, abbreviation: 'RVR09', name: 'Reina-Valera 1909', language: 'es' },
+  { id: 3, abbreviation: 'RVR60', name: 'Reina-Valera 1960', language: 'es' },
+]
+
+describe('selectDefaultBibleVersionId', () => {
+  it('prefers Reina-Valera 1960 for Spanish browsers', () => {
+    expect(selectDefaultBibleVersionId(versions, 'es-ES')).toBe(3)
+  })
+
+  it('uses an available English version for English browsers', () => {
+    expect(selectDefaultBibleVersionId(versions, 'en-US')).toBe(1)
+  })
+
+  it('falls back to the first available version for unsupported languages', () => {
+    expect(selectDefaultBibleVersionId(versions, 'fr-FR')).toBe(1)
+  })
+})

--- a/src/lib/defaultBibleVersion.ts
+++ b/src/lib/defaultBibleVersion.ts
@@ -1,0 +1,49 @@
+import type { ApiVersion } from '@/lib/bibleApi'
+
+export const BIBLE_VERSION_STORAGE_KEY = 'tulia_version_id'
+
+export function getStoredBibleVersionId(): number | null {
+  const raw = localStorage.getItem(BIBLE_VERSION_STORAGE_KEY)
+  const id = Number(raw)
+
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+export function getBrowserLanguage(): string {
+  return navigator.languages?.[0] ?? navigator.language ?? ''
+}
+
+export function selectDefaultBibleVersionId(
+  versions: ApiVersion[],
+  browserLanguage: string,
+  fallbackVersionId = 1,
+): number {
+  if (versions.length === 0) return fallbackVersionId
+
+  const language = browserLanguage.toLowerCase()
+  const languageCode = language.split('-')[0]
+  const byLanguage = versions.filter(versionMatchesLanguage(languageCode))
+
+  if (languageCode === 'es') {
+    return byLanguage.find(isReinaValera1960)?.id ?? byLanguage[0]?.id ?? versions[0].id
+  }
+
+  if (languageCode === 'en') {
+    return byLanguage[0]?.id ?? versions[0].id
+  }
+
+  return byLanguage[0]?.id ?? versions[0].id
+}
+
+function versionMatchesLanguage(languageCode: string) {
+  return (version: ApiVersion) => version.language.toLowerCase().split('-')[0] === languageCode
+}
+
+function isReinaValera1960(version: ApiVersion): boolean {
+  const value = `${version.abbreviation} ${version.name}`.toLowerCase()
+
+  return (
+    value.includes('1960') &&
+    (value.includes('reina') || value.includes('valera') || value.includes('rvr') || value.includes('rv60'))
+  )
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,12 +2,12 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
+import { getBrowserLocale, getStoredAppLocale, selectDefaultAppLocale } from '@/lib/defaultAppLocale'
 
-const savedLocale = localStorage.getItem('locale')
-const osLocale   = navigator.language.startsWith('es') ? 'es' : 'en'
+const locale = getStoredAppLocale() ?? selectDefaultAppLocale(getBrowserLocale())
 
 i18n.use(initReactI18next).init({
-  lng: savedLocale ?? osLocale,
+  lng: locale,
   fallbackLng: 'en',
   resources: {
     en: { translation: en },

--- a/src/lib/store/useUIStore.ts
+++ b/src/lib/store/useUIStore.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand'
 import i18n from '@/lib/i18n'
+import {
+  APP_LOCALE_STORAGE_KEY,
+  getBrowserLocale,
+  getStoredAppLocale,
+  selectDefaultAppLocale,
+  type AppLocale,
+} from '@/lib/defaultAppLocale'
 
 type Toast = {
   id: string
@@ -10,7 +17,7 @@ type Toast = {
 
 export type FontSize    = 'sm' | 'base' | 'lg'
 export type Theme       = 'dark' | 'light'
-export type Locale      = 'en' | 'es'
+export type Locale      = AppLocale
 export type Panel       = 'favorites' | 'my-notes' | 'friends' | 'chat'
 export type ReadingMode = 'flow' | 'verse'
 
@@ -56,7 +63,7 @@ type UIStore = {
 const savedFontSize    = (localStorage.getItem('fontSize')    as FontSize)    ?? 'base'
 const savedTheme       = (localStorage.getItem('theme')       as Theme)       ?? 'light'
 const savedReadingMode = (localStorage.getItem('readingMode') as ReadingMode) ?? 'verse'
-const savedLocale      = (localStorage.getItem('locale')      as Locale)      ?? null
+const savedLocale      = getStoredAppLocale()
 applyTheme(savedTheme)
 
 export const useUIStore = create<UIStore>((set) => ({
@@ -71,7 +78,7 @@ export const useUIStore = create<UIStore>((set) => ({
   activePanel: null,
   fontSize: savedFontSize,
   theme: savedTheme,
-  locale: savedLocale ?? (navigator.language.startsWith('es') ? 'es' : 'en'),
+  locale: savedLocale ?? selectDefaultAppLocale(getBrowserLocale()),
   readingMode: savedReadingMode,
 
   openCommandPalette: () => set({ commandPaletteOpen: true }),
@@ -110,7 +117,7 @@ export const useUIStore = create<UIStore>((set) => ({
   },
 
   setLocale: (l) => {
-    localStorage.setItem('locale', l)
+    localStorage.setItem(APP_LOCALE_STORAGE_KEY, l)
     void i18n.changeLanguage(l)
     set({ locale: l })
   },

--- a/src/lib/store/useVerseStore.ts
+++ b/src/lib/store/useVerseStore.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
 import { bibleApi, ApiBook, ApiVersion } from '@/lib/bibleApi'
+import {
+  BIBLE_VERSION_STORAGE_KEY,
+  getBrowserLanguage,
+  getStoredBibleVersionId,
+  selectDefaultBibleVersionId,
+} from '@/lib/defaultBibleVersion'
 
 export interface Book {
   id: string  // slug used as id for compatibility
@@ -52,7 +58,7 @@ function testament(bookNumber: number): 'old' | 'new' {
 }
 
 export const useVerseStore = create<VerseState>((set, get) => ({
-  versionId: Number(localStorage.getItem('tulia_version_id')) || 1,
+  versionId: getStoredBibleVersionId() ?? 1,
   versions: [],
   books: [],
   selectedBook: '',
@@ -67,21 +73,31 @@ export const useVerseStore = create<VerseState>((set, get) => ({
   loadVersions: async () => {
     try {
       const versions = await bibleApi.versions()
-      set({ versions })
+      const storedVersionId = getStoredBibleVersionId()
+      set({
+        versions,
+        versionId: storedVersionId ?? selectDefaultBibleVersionId(versions, getBrowserLanguage(), get().versionId),
+      })
     } catch (e) {
       console.error('Failed to load versions', e)
     }
   },
 
   setVersion: async (id) => {
-    localStorage.setItem('tulia_version_id', String(id))
+    localStorage.setItem(BIBLE_VERSION_STORAGE_KEY, String(id))
     set({ versionId: id, books: [], verses: [], selectedVerseId: null, selectedVerseIds: [], studyVerseId: null })
     await get().loadBooks()
   },
 
   loadBooks: async () => {
-    const { versionId } = get()
+    let { versionId, versions } = get()
     try {
+      if (!getStoredBibleVersionId() && versions.length === 0) {
+        versions = await bibleApi.versions()
+        versionId = selectDefaultBibleVersionId(versions, getBrowserLanguage(), versionId)
+        set({ versions, versionId })
+      }
+
       const apiBooks: ApiBook[] = await bibleApi.books(versionId)
       const books: Book[] = apiBooks.map(b => ({
         id: b.slug,


### PR DESCRIPTION
## Summary
- Select the initial Bible version from the browser language when no preferred version is stored
- Prefer Reina-Valera 1960 for Spanish browsers and an available English version for English browsers
- Select the initial app locale from the browser language when no app locale is stored

## Verification
- pnpm test -- src/lib/defaultAppLocale.test.ts src/lib/defaultBibleVersion.test.ts src/lib/__tests__/i18n.test.ts src/lib/bibleRefs.test.ts
- pnpm build