### PR TITLE
Collaborative study canvas + note types + multi-verse context menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+> **tulia.study** — collaborative Bible study desktop app. React 18 + Vite 8 + TypeScript 5 + Tailwind 3 + Zustand 5, packaged as a Tauri 2 desktop binary. Backend is a separate Laravel API (`verbum`).
+
+> **Note:** `CLAUDE.md` exists for Claude Code users but contains stale claims (e.g. "highlights are client-side", "AuthModal not connected"). This file is the authoritative source.
+
+## Commands
+
+```bash
+pnpm dev              # Vite web dev server on port 1420
+pnpm tauri:dev        # Desktop dev with hot reload — use PowerShell on Windows (cargo PATH broken in Git Bash)
+pnpm build            # Vite → out/
+pnpm tauri:build      # Full desktop binary
+pnpm test             # vitest run (happy-dom) — 4 test files in src/lib/
+pnpm test:watch       # vitest watch mode
+pnpm deploy           # pnpm build && firebase deploy --only hosting
+```
+
+No lint or typecheck scripts exist.
+
+## Architecture
+
+### 16 Zustand stores (src/lib/store/)
+
+| Store | Responsibility |
+|---|---|
+| `useAuthStore` | Login/register/logout via `/api/auth/*`. Token in localStorage as `verbum_token`. |
+| `useVerseStore` | Bible versions, books, chapters — API-backed via `src/lib/bibleApi.ts` |
+| `useNoteStore` | CRUD notes per verse via `/api/verses/{id}/notes` |
+| `useHighlightStore` | Highlights via `/api/verses/{id}/highlights` and `/api/highlights/batch` — **server-backed** |
+| `useBookmarkStore` | Bookmarks via `/api/verses/{id}/bookmark` |
+| `useUIStore` | Modals, panels, theme, font size, toasts, reading mode |
+| `useStudyStore` | Collaborative study sessions (create, join, invite, end) |
+| `useChatStore` | Real-time chat via Laravel Echo + Reverb |
+| `useFriendStore` | Friends, friend requests, user search |
+| `useNotificationStore` | Notifications with polling + Reverb push |
+| `usePresenceStore` | Realtime "who's reading this chapter" (friends only) |
+| `useActivityStore` | Recent friend activity on verses (30s TTL) |
+| `useCrossRefStore` | Cross-references per verse/chapter |
+| `useCompareStore` | Compare Bible versions side by side |
+| `useBiblePreviewStore` | Bible passage preview (used in study canvas InsertVerseModal) |
+| `useContextMenuStore` | Right-click context menu state |
+
+### API conventions (`src/lib/api.ts`)
+
+- Reads `verbum_token` from localStorage, auto-attaches `Authorization: Bearer`.
+- `api.patch()` and `api.delete()` send as POST with `_method: 'PATCH'` / `_method: 'DELETE'` in the JSON body (Laravel convention).
+- Base URL from `VITE_API_URL` env var (default `https://verbum.test`).
+
+### Key facts
+
+- **No router** — navigation is state-driven via `useVerseStore`.
+- **Path alias:** `@/*` → `./src/*`.
+- **Build output:** `out/` (not `dist/`).
+- **Verse IDs:** slug format `book-chapter-verse` in UI; numeric `apiId` for backend calls.
+- **Verse display formats:** `flow` (continuous paragraph with superscript numbers) and `verse` (each verse in its own block).
+
+### UI Layout
+
+```
+Sidebar (240px) | Left Panel (420px, toggleable) | Main | Right Panel (420px, toggleable)
+Books/Chapters  | Favorites / My Notes / Friends   | Verses| Study / Commentary
+                 / Chat / My Studies
+```
+
+### Design system
+
+- **Colors:** Dark theme with gold accent `#c8a96a`. All colors are CSS custom properties in `tailwind.config.ts`, referenced as `var(--color-*)`.
+- **Font:** Inter (body, `font-sans`), Lora (reading, `font-reading`). Sizes: `2xs`(10px) to `lg`(15px).
+- **Theme toggle:** sets `data-theme` attribute on `<html>`.
+- **Design patterns manifesto:** `docs/design-patterns.md` — consult before creating/modifying UI components.
+
+### Realtime systems (4 coexist)
+
+| System | Protocol | Purpose |
+|---|---|---|
+| Hocuspocus | WebSocket (`ws://localhost:1234` / `wss://tulia.study/hocuspocus/`) | Yjs CRDT sync for collaborative study canvas (React Flow) |
+| Laravel Echo + Reverb | WebSocket (`localhost:8080` / `tulia.study:443`) | Chat messages, typing, read receipts |
+| Presence channels | Reverb | Who's reading the same chapter (friends only) |
+| Firebase Cloud Messaging | HTTP | Push notifications |
+
+## Dead code
+
+- `src/lib/supabase/client.ts` — not imported anywhere. Supabase npm packages are in `dependencies` but unused.
+
+## Release
+
+- GitHub Actions on `v*` tags builds Tauri binaries (macOS universal, Linux, Windows).
+- Tag must match `package.json` version exactly (validated in CI step).
+- Uses `tauri-apps/tauri-action@v0`, pnpm 10.20, Node 22, Rust stable.
+- Updater configured in `tauri.conf.json` with GitHub releases endpoint.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>tulia.study</title>
     <meta name="description" content="Collaborative Bible study" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" shapeRendering="crispEdges">
+  <style>
+    @media (prefers-color-scheme: dark) {
+      .ink { stroke: #eaeaea; fill: #eaeaea; }
+      .base { fill: #c8a96a; }
+    }
+    @media (prefers-color-scheme: light) {
+      .ink { stroke: #111; fill: #111; }
+      .base { fill: #b8943a; }
+    }
+  </style>
+  <line class="ink" x1="8" y1="3" x2="3" y2="12" stroke="#eaeaea" stroke-width="1.2"/>
+  <line class="ink" x1="8" y1="3" x2="13" y2="12" stroke="#eaeaea" stroke-width="1.2"/>
+  <rect class="base" x="3" y="11" width="10" height="2" fill="#c8a96a"/>
+  <rect class="ink" x="7" y="2" width="2" height="2" fill="#eaeaea"/>
+  <rect class="ink" x="2" y="11" width="2" height="2" fill="#eaeaea"/>
+  <rect class="ink" x="12" y="11" width="2" height="2" fill="#eaeaea"/>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none" shapeRendering="geometricPrecision">
+  <line x1="32" y1="14" x2="14" y2="48" stroke="#eaeaea" stroke-width="1.6" stroke-linecap="round"/>
+  <line x1="32" y1="14" x2="50" y2="48" stroke="#eaeaea" stroke-width="1.6" stroke-linecap="round"/>
+  <line x1="14" y1="48" x2="50" y2="48" stroke="#c8a96a" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="14" r="3.2" fill="#eaeaea"/>
+  <circle cx="14" cy="48" r="3.2" fill="#eaeaea"/>
+  <circle cx="50" cy="48" r="3.2" fill="#eaeaea"/>
+</svg>

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { cn } from '@/lib/cn'
+import { LogoStacked } from '@/components/brand/Logo'
 
 interface AuthModalProps {
   open: boolean
@@ -151,7 +152,11 @@ export function AuthModal({ open, onClose, initialMode = 'login' }: AuthModalPro
 
         {/* Mode tabs — only for login/register */}
         {isAuth && (
-          <div className="flex gap-1 mb-4 bg-bg-tertiary rounded-lg p-1">
+          <>
+            <div className="flex justify-center mb-5">
+              <LogoStacked symbolSize={40} textSize={18} />
+            </div>
+            <div className="flex gap-1 mb-4 bg-bg-tertiary rounded-lg p-1">
             {(['login', 'register'] as Mode[]).map(m => (
               <button
                 key={m}
@@ -167,6 +172,7 @@ export function AuthModal({ open, onClose, initialMode = 'login' }: AuthModalPro
               </button>
             ))}
           </div>
+          </>
         )}
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-3" noValidate>

--- a/src/components/brand/Logo.tsx
+++ b/src/components/brand/Logo.tsx
@@ -1,0 +1,78 @@
+import { cn } from '@/lib/cn'
+
+interface LogoIconProps {
+  size?: number
+  className?: string
+  inkColor?: string
+  accentColor?: string
+}
+
+export function LogoIcon({
+  size = 22,
+  className,
+  inkColor = 'currentColor',
+  accentColor = '#c8a96a',
+}: LogoIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      className={className}
+      shapeRendering="geometricPrecision"
+      aria-hidden="true"
+    >
+      <line x1="32" y1="14" x2="14" y2="48" stroke={inkColor} strokeWidth="1.6" strokeLinecap="round" />
+      <line x1="32" y1="14" x2="50" y2="48" stroke={inkColor} strokeWidth="1.6" strokeLinecap="round" />
+      <line x1="14" y1="48" x2="50" y2="48" stroke={accentColor} strokeWidth="4" strokeLinecap="round" />
+      <circle cx="32" cy="14" r="3.2" fill={inkColor} />
+      <circle cx="14" cy="48" r="3.2" fill={inkColor} />
+      <circle cx="50" cy="48" r="3.2" fill={inkColor} />
+    </svg>
+  )
+}
+
+interface LogoProps {
+  symbolSize?: number
+  textSize?: number
+  className?: string
+}
+
+export function Logo({ symbolSize = 20, textSize = 13, className }: LogoProps) {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <LogoIcon size={symbolSize} className="text-text-primary shrink-0" />
+      <span
+        className="font-reading tracking-[-0.02em] leading-none whitespace-nowrap"
+        style={{ fontSize: textSize }}
+      >
+        <span className="text-text-primary">tulia</span>
+        <span className="text-accent">.</span>
+        <span className="text-text-primary">study</span>
+      </span>
+    </div>
+  )
+}
+
+interface LogoStackedProps {
+  symbolSize?: number
+  textSize?: number
+  className?: string
+}
+
+export function LogoStacked({ symbolSize = 48, textSize = 22, className }: LogoStackedProps) {
+  return (
+    <div className={cn('flex flex-col items-center gap-3.5', className)}>
+      <LogoIcon size={symbolSize} className="text-text-primary" />
+      <span
+        className="font-reading tracking-[-0.02em] leading-none whitespace-nowrap"
+        style={{ fontSize: textSize }}
+      >
+        <span className="text-text-primary">tulia</span>
+        <span className="text-accent">.</span>
+        <span className="text-text-primary">study</span>
+      </span>
+    </div>
+  )
+}

--- a/src/components/notes/NoteInput.tsx
+++ b/src/components/notes/NoteInput.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNoteStore } from '@/lib/store/useNoteStore'
+import { useVerseStore } from '@/lib/store/useVerseStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { cn } from '@/lib/cn'
@@ -19,6 +20,7 @@ export default function NoteInput({ verseApiId, verseApiIds }: NoteInputProps) {
   const [isPublic, setIsPublic] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const addNote = useNoteStore((s) => s.addNote)
+  const closeStudyPanel = useVerseStore((s) => s.closeStudyPanel)
   const addToast = useUIStore((s) => s.addToast)
   const openAuthModal = useUIStore((s) => s.openAuthModal)
   const user = useAuthStore((s) => s.user)
@@ -56,6 +58,7 @@ export default function NoteInput({ verseApiId, verseApiIds }: NoteInputProps) {
       await Promise.all(targetVerseApiIds.map((id) => addNote(id, trimmed, undefined, isPublic)))
       addToast(isGroupNote ? t('notes.savedForVerses', { count: targetVerseApiIds.length }) : t('notes.saved'), 'success')
       setContent('')
+      if (isGroupNote) closeStudyPanel()
     } catch {
       addToast(t('notes.saveFailed'), 'error')
     } finally {

--- a/src/components/notes/NoteItem.tsx
+++ b/src/components/notes/NoteItem.tsx
@@ -6,6 +6,8 @@ import { useNoteStore } from '@/lib/store/useNoteStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { cn } from '@/lib/cn'
+import { NOTE_TYPE_LIST, getNoteTypeDef } from '@/lib/noteTypes'
+import type { NoteType } from '@/lib/noteTypes'
 import NoteEditor from '@/components/notes/NoteEditor'
 
 interface NoteItemProps {
@@ -102,6 +104,15 @@ function ReplyInput({ onSubmit, onCancel }: { onSubmit: (body: string) => void; 
   )
 }
 
+function SettingsIcon({ className }: { className?: string }) {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  )
+}
+
 export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, showReplyToggle = true, hiddenParentIds }: NoteItemProps) {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
@@ -109,6 +120,7 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
   const [confirmingPublish, setConfirmingPublish] = useState(false)
   const [showReply, setShowReply] = useState(false)
   const [repliesOpen, setRepliesOpen] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   useEffect(() => {
     if (!confirmingPublish) return
@@ -116,10 +128,17 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
     return () => clearTimeout(id)
   }, [confirmingPublish])
 
+  useEffect(() => {
+    if (!settingsOpen) return
+    if (confirmingDelete) setConfirmingDelete(false)
+    if (confirmingPublish) setConfirmingPublish(false)
+  }, [settingsOpen])
+
   const updateNote = useNoteStore((s) => s.updateNote)
   const deleteNote = useNoteStore((s) => s.deleteNote)
   const addNote = useNoteStore((s) => s.addNote)
   const toggleNoteVisibility = useNoteStore((s) => s.toggleNoteVisibility)
+  const updateNoteType = useNoteStore((s) => s.updateNoteType)
   const likeNote = useNoteStore((s) => s.likeNote)
   const unlikeNote = useNoteStore((s) => s.unlikeNote)
   const addToast = useUIStore((s) => s.addToast)
@@ -129,6 +148,7 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
   const relativeTime = formatRelativeTime(note.created_at)
   const canManage = user?.id === note.user?.id
   const isOrphan = depth === 0 && note.parent_id != null && hiddenParentIds?.has(note.parent_id)
+  const typeDef = getNoteTypeDef(note.note_type)
 
   async function handleSave(body: string) {
     if (!canManage) return
@@ -161,9 +181,18 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
     }
   }
 
+  function handleTypeChange(newType: NoteType) {
+    updateNoteType(verseApiId, note.id, newType)
+  }
+
   return (
     <div className={cn('note-enter', depth > 0 && 'pl-4 border-l border-border-subtle')}>
-      <div className="group flex gap-2.5 py-1.5">
+      <div className={cn(
+        'group relative flex gap-2.5 py-1.5 px-2 -mx-2 rounded-md border-l-2 transition-colors duration-150',
+        typeDef.bgClass,
+        typeDef.borderClass,
+        settingsOpen && 'bg-bg-tertiary/50',
+      )}>
         <Avatar name={authorName} email={note.user?.email} />
 
         <div className="flex-1 min-w-0">
@@ -176,7 +205,12 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
           ) : (
             <>
               <div className="flex items-center gap-1.5">
-                <span className="text-xs font-medium text-text-primary">{authorName}</span>
+                <span className="flex items-center gap-1">
+                  <span className={cn('shrink-0', typeDef.indicatorClass)}>
+                    <typeDef.icon />
+                  </span>
+                  <span className="text-xs font-medium text-text-primary">{authorName}</span>
+                </span>
                 <span className="text-[10px] text-text-muted">{relativeTime}</span>
                 {canManage ? (
                   <button
@@ -204,9 +238,11 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
                       : (note.is_public ? t('notes.public') : t('notes.private'))}
                   </button>
                 ) : (
-                  <span className="text-[9px] px-1.5 py-px rounded-full font-medium bg-accent/15 text-accent border border-accent/30">
-                    {t('notes.public')}
-                  </span>
+                  note.is_public && (
+                    <span className="text-[9px] px-1.5 py-px rounded-full font-medium bg-accent/15 text-accent border border-accent/30">
+                      {t('notes.public')}
+                    </span>
+                  )
                 )}
               </div>
 
@@ -216,7 +252,10 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
                 </p>
               )}
 
-              <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap break-words mt-0.5">
+              <p className={cn(
+                'text-sm text-text-secondary leading-relaxed whitespace-pre-wrap break-words mt-0.5',
+                typeDef.italic && 'italic',
+              )}>
                 {note.body}
               </p>
 
@@ -248,47 +287,85 @@ export default function NoteItem({ note, verseApiId, depth = 0, replyParentId, s
                 <div className="flex-1" />
 
                 {canManage && (
-                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                    {confirmingDelete ? (
-                      <>
-                        <span className="text-[10px] text-text-muted mr-1">{t('notes.confirmDelete')}</span>
-                        <button
-                          type="button"
-                          onClick={handleDelete}
-                          className="text-[10px] px-1.5 py-0.5 rounded text-red-400 hover:bg-red-400/10 transition-colors font-medium"
-                        >
-                          {t('notes.deleteYes')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setConfirmingDelete(false)}
-                          className="text-[10px] px-1.5 py-0.5 rounded text-text-secondary hover:bg-bg-primary transition-colors"
-                        >
-                          {t('notes.deleteNo')}
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() => setIsEditing(true)}
-                          className="text-[10px] px-1.5 py-0.5 rounded text-text-muted hover:text-text-secondary hover:bg-bg-primary transition-colors"
-                        >
-                          {t('notes.edit')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setConfirmingDelete(true)}
-                          className="text-[10px] px-1.5 py-0.5 rounded text-text-muted hover:text-red-400 hover:bg-red-400/10 transition-colors"
-                        >
-                          {t('notes.delete')}
-                        </button>
-                      </>
+                  <button
+                    type="button"
+                    onClick={() => setSettingsOpen(!settingsOpen)}
+                    className={cn(
+                      'text-text-muted hover:text-text-secondary transition-colors rounded p-0.5',
+                      settingsOpen && 'text-accent bg-accent/10',
                     )}
-                  </div>
+                    title={t('notes.settings')}
+                  >
+                    <SettingsIcon />
+                  </button>
                 )}
               </div>
             </>
+          )}
+
+          {settingsOpen && canManage && (
+            <div className="mt-2 bg-bg-tertiary rounded-lg border border-border-subtle p-3 animate-in fade-in slide-in-from-top-1 duration-150">
+              <div className="flex items-center gap-2 mb-2.5">
+                {NOTE_TYPE_LIST.map((nt) => (
+                  <button
+                    key={nt.type}
+                    type="button"
+                    onClick={() => handleTypeChange(nt.type)}
+                    className={cn(
+                      'flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium transition-all duration-150 border',
+                      note.note_type === nt.type || (!note.note_type && nt.type === 'note')
+                        ? `${nt.borderClass.replace('border-l-', 'border-')} ${nt.bgClass} ${nt.indicatorClass}`
+                        : 'border-transparent text-text-muted hover:text-text-secondary hover:bg-bg-primary',
+                    )}
+                    title={t(nt.labelKey as any)}
+                  >
+                    <nt.icon />
+                    <span className="hidden sm:inline">{t(nt.labelKey as any)}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex items-center gap-1 pt-2 border-t border-border-subtle">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSettingsOpen(false)
+                    setIsEditing(true)
+                  }}
+                  className="text-[11px] px-2 py-1 rounded text-text-secondary hover:text-text-primary hover:bg-bg-primary transition-colors"
+                >
+                  {t('notes.edit')}
+                </button>
+
+                {confirmingDelete ? (
+                  <>
+                    <span className="text-[10px] text-text-muted ml-1">{t('notes.confirmDelete')}</span>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      className="text-[10px] px-1.5 py-0.5 rounded text-red-400 hover:bg-red-400/10 transition-colors font-medium"
+                    >
+                      {t('notes.deleteYes')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingDelete(false)}
+                      className="text-[10px] px-1.5 py-0.5 rounded text-text-secondary hover:bg-bg-primary transition-colors"
+                    >
+                      {t('notes.deleteNo')}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingDelete(true)}
+                    className="text-[11px] px-2 py-1 rounded text-text-muted hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                  >
+                    {t('notes.delete')}
+                  </button>
+                )}
+              </div>
+            </div>
           )}
 
           {showReply && (

--- a/src/components/realtime/PresenceAvatars.tsx
+++ b/src/components/realtime/PresenceAvatars.tsx
@@ -83,8 +83,6 @@ function UserTooltip({
 export function PresenceAvatars({ users }: PresenceAvatarsProps) {
   const { t } = useTranslation()
 
-  if (users.length === 0) return null
-
   const [hovered,  setHovered]  = useState<{ id: number; rect: DOMRect } | null>(null)
   const [closing,  setClosing]  = useState(false)
   const leaveTimer  = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -109,6 +107,8 @@ export function PresenceAvatars({ users }: PresenceAvatarsProps) {
       window.removeEventListener('resize', close)
     }
   }, [hovered])
+
+  if (users.length === 0) return null
 
   const visible  = users.slice(0, MAX_VISIBLE)
   const overflow = users.length - MAX_VISIBLE

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { StartStudyModal } from '@/components/study/StartStudyModal'
 import { cn } from '@/lib/cn'
 import { modKey } from '@/lib/platform'
 import { BookOpen } from 'lucide-react'
+import { Logo } from '@/components/brand/Logo'
 
 interface NavItemProps {
   icon: ReactNode
@@ -144,10 +145,7 @@ export function Sidebar() {
     <div className="w-full h-full bg-bg-secondary border-r border-border-subtle flex flex-col overflow-hidden">
       {/* App name */}
       <div className="px-4 pt-3 pb-2 shrink-0">
-        <span className="font-medium text-md">
-          <span className="text-accent">tulia</span>
-          <span className="text-text-muted">.study</span>
-        </span>
+        <Logo symbolSize={20} textSize={14} />
       </div>
 
       <div className="px-2 pb-2">

--- a/src/components/study/MyStudiesPanel.tsx
+++ b/src/components/study/MyStudiesPanel.tsx
@@ -15,6 +15,7 @@ export function MyStudiesPanel() {
   const acceptInvitation = useStudyStore((s) => s.acceptInvitation);
   const declineInvitation = useStudyStore((s) => s.declineInvitation);
   const enterStudyMode = useUIStore((s) => s.enterStudyMode);
+  const closePanel     = useUIStore((s) => s.closePanel);
   const [filter, setFilter] = useState<'all' | 'active' | 'ended'>('all');
 
   useEffect(() => {
@@ -47,13 +48,24 @@ export function MyStudiesPanel() {
     <div className="h-full flex flex-col bg-bg-secondary border-r border-border-subtle">
       <div className="px-4 pt-3 pb-2 shrink-0 flex items-center justify-between">
         <span className="font-medium text-md text-text-primary">My Studies</span>
-        <button
-          onClick={() => { loadMyStudies(); loadInvitations(); }}
-          className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
-          title="Refresh"
-        >
-          <RefreshCw className="w-3.5 h-3.5" />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => { loadMyStudies(); loadInvitations(); }}
+            className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+            title="Refresh"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={closePanel}
+            className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+            title="Close"
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+              <path d="M2 2l10 10M12 2L2 12" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {/* Pending invitations */}

--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -151,6 +151,7 @@ export function VerseList() {
   const loadNotes  = useNoteStore((s) => s.loadNotes)
   const highlights = useHighlightStore((s) => s.highlights)
   const addHighlight = useHighlightStore((s) => s.addHighlight)
+  const removeHighlight = useHighlightStore((s) => s.removeHighlight)
   const loadHighlightsForChapter = useHighlightStore((s) => s.loadHighlightsForChapter)
 
   const bookmarkedIds  = useBookmarkStore((s) => s.bookmarkedIds)
@@ -229,15 +230,36 @@ export function VerseList() {
 
   function addVerseHighlight(verse: Verse, color: HighlightColor) {
     if (requireLogin()) return
-    addHighlight(verse.apiId, 0, verse.text.length, color).catch((error) => {
-      if (isAuthError(error)) {
-        addToast(t('study.loginRequired'), 'error', {
-          action: { label: t('auth.logIn'), onClick: openAuthModal },
-        })
-        return
-      }
-      addToast(t('toast.highlightFailed'), 'error')
-    })
+    const existingHighlights = highlights[verse.apiId] ?? []
+    Promise.all(existingHighlights.map(h => removeHighlight(verse.apiId, h.id)))
+      .then(() => addHighlight(verse.apiId, 0, verse.text.length, color))
+      .catch((error) => {
+        if (isAuthError(error)) {
+          addToast(t('study.loginRequired'), 'error', {
+            action: { label: t('auth.logIn'), onClick: openAuthModal },
+          })
+          return
+        }
+        addToast(t('toast.highlightFailed'), 'error')
+      })
+  }
+
+  function addVerseHighlights(verses: Verse[], color: HighlightColor) {
+    if (requireLogin()) return
+    Promise.all(verses.map(async v => {
+      const existingHighlights = highlights[v.apiId] ?? []
+      await Promise.all(existingHighlights.map(h => removeHighlight(v.apiId, h.id)))
+      await addHighlight(v.apiId, 0, v.text.length, color)
+    }))
+      .catch((error) => {
+        if (isAuthError(error)) {
+          addToast(t('study.loginRequired'), 'error', {
+            action: { label: t('auth.logIn'), onClick: openAuthModal },
+          })
+          return
+        }
+        addToast(t('toast.highlightFailed'), 'error')
+      })
   }
 
   function buildVerseMenu(verse: Verse): MenuItem[] {
@@ -322,15 +344,106 @@ export function VerseList() {
     return items
   }
 
+  function buildMultiVerseMenu(): MenuItem[] {
+    const multiVerses = verses.filter(v => selectedVerseIds.includes(v.id))
+    const allBookmarked = multiVerses.every(v => bookmarkedIds.has(v.apiId))
+
+    const items: MenuItem[] = [
+      {
+        type: 'action',
+        label: t('study.copyVerseText'),
+        icon: <IconCopy />,
+        shortcut: `${modKey}C`,
+        onClick: () => {
+          const text = multiVerses.map(v => v.text).join('\n\n')
+          navigator.clipboard.writeText(text)
+          addToast(t('toast.copied'), 'success')
+        },
+      },
+      {
+        type: 'action',
+        label: t('verse.copyReference'),
+        icon: <IconCopy />,
+        onClick: () => {
+          const refs = multiVerses.map(v => `${bookName} ${v.chapter}:${v.verse}`).join(', ')
+          navigator.clipboard.writeText(refs)
+          addToast(t('verse.copiedRef', { ref: refs }), 'success')
+        },
+      },
+      { type: 'separator' },
+      { type: 'label', text: t('verse.highlightVerse') },
+      {
+        type: 'action', label: t('study.colorYellow'), icon: <ColorDot color="#e5c07b" />,
+        onClick: () => addVerseHighlights(multiVerses, 'yellow'),
+      },
+      {
+        type: 'action', label: t('study.colorBlue'), icon: <ColorDot color="#61afef" />,
+        onClick: () => addVerseHighlights(multiVerses, 'blue'),
+      },
+      {
+        type: 'action', label: t('study.colorGreen'), icon: <ColorDot color="#98c379" />,
+        onClick: () => addVerseHighlights(multiVerses, 'green'),
+      },
+      { type: 'separator' },
+      {
+        type: 'action',
+        label: t('verse.addNote'),
+        icon: <IconNote />,
+        onClick: () => {
+          if (requireLogin()) return
+          openStudyPanel(multiVerses[0].id)
+        },
+      },
+      { type: 'separator' },
+      {
+        type: 'action',
+        label: allBookmarked ? t('verse.removeFromFavorites') : t('verse.addToFavorites'),
+        icon: <IconStar filled={allBookmarked} />,
+        onClick: () => {
+          if (requireLogin()) return
+          Promise.all(multiVerses.map(v =>
+            toggleBookmark(v.apiId).then(() => {
+              if (!bookmarkedIds.has(v.apiId)) {
+                setBurstId(v.apiId)
+                setTimeout(() => setBurstId(null), 900)
+              }
+            }),
+          ))
+            .catch((error) => {
+              if (isAuthError(error)) {
+                addToast(t('study.loginRequired'), 'error', {
+                  action: { label: t('auth.logIn'), onClick: openAuthModal },
+                })
+                return
+              }
+              addToast(t('toast.bookmarkFailed'), 'error')
+            })
+        },
+      },
+    ]
+
+    return items
+  }
+
   function handleContextMenu(e: React.MouseEvent, verse: Verse) {
     e.preventDefault()
     e.stopPropagation()
-    openMenu(e.clientX, e.clientY, buildVerseMenu(verse))
+    if (selectedVerseIds.includes(verse.id) && selectedVerseIds.length > 1) {
+      openMenu(e.clientX, e.clientY, buildMultiVerseMenu())
+    } else {
+      selectVerse(verse.id)
+      openMenu(e.clientX, e.clientY, buildVerseMenu(verse))
+    }
   }
 
   function openVerseMenuFromButton(target: HTMLElement, verse: Verse) {
     const rect = target.getBoundingClientRect()
-    openMenu(rect.right - 12, rect.bottom + 8, buildVerseMenu(verse))
+    if (selectedVerseIds.includes(verse.id) && selectedVerseIds.length > 1) {
+      openMenu(rect.right - 12, rect.bottom + 8, buildMultiVerseMenu())
+    } else {
+      selectVerse(verse.id)
+      openMenu(rect.right - 12, rect.bottom + 8, buildVerseMenu(verse))
+    }
   }
 
   // ── Verse number pill ────────────────────────────────────────────────────
@@ -423,8 +536,8 @@ export function VerseList() {
         <div className="flex-1 overflow-y-auto no-scrollbar relative">
 
           {/* Mobile keeps navigation/display primary; study tools appear after selecting a verse. */}
-          <div className="sticky top-0 z-10 border-b border-border-subtle bg-bg-secondary px-3 py-2 md:border-b-0 md:bg-transparent md:px-4 md:py-2 pointer-events-none">
-            <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="sticky top-0 z-10 bg-bg-secondary pointer-events-none">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border-subtle px-3 py-2 md:border-b-0 md:bg-transparent md:px-4 md:py-2">
               <div className="hidden md:block pointer-events-auto">
                 <PresenceAvatars users={others} />
               </div>
@@ -489,21 +602,9 @@ export function VerseList() {
                 </div>
               </div>
             </div>
-          </div>
-
-          <div className="max-w-[660px] mx-auto px-4 md:px-10 pt-4 pb-16">
-
-            {/* Chapter heading */}
-            <div className="mb-6 md:mb-8 text-center">
-              <h1 className="font-reading text-xl md:text-2xl font-medium tracking-tight text-text-primary">{bookName}</h1>
-              <p className="mt-1 text-[10px] font-sans font-semibold uppercase tracking-[0.18em] text-accent/70">
-                {t('layout.chapter', { n: selectedChapter })}
-              </p>
-              <div className="mt-4 mx-auto w-8 h-px bg-accent/30" />
-            </div>
 
             {selectedVerseIds.length > 0 && (
-              <div className="mb-4 flex flex-col gap-2 bg-accent/[0.08] border border-accent/[0.15] rounded-lg px-3 py-2 text-xs animate-in fade-in slide-in-from-top-1 duration-200 md:flex-row md:items-center md:justify-between">
+              <div className="pointer-events-auto flex flex-col gap-2 bg-accent/[0.08] border-b border-accent/[0.15] px-3 py-2 text-xs animate-in fade-in slide-in-from-top-1 duration-200 md:flex-row md:items-center md:justify-between md:px-4">
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-text-secondary">
                     {t('verse.selectedVerses', { count: selectedVerseIds.length })}
@@ -546,6 +647,18 @@ export function VerseList() {
                 </div>
               </div>
             )}
+          </div>
+
+          <div className="max-w-[660px] mx-auto px-4 md:px-10 pt-4 pb-16">
+
+            {/* Chapter heading */}
+            <div className="mb-6 md:mb-8 text-center">
+              <h1 className="font-reading text-xl md:text-2xl font-medium tracking-tight text-text-primary">{bookName}</h1>
+              <p className="mt-1 text-[10px] font-sans font-semibold uppercase tracking-[0.18em] text-accent/70">
+                {t('layout.chapter', { n: selectedChapter })}
+              </p>
+              <div className="mt-4 mx-auto w-8 h-px bg-accent/30" />
+            </div>
 
             {/* ── Flow mode ── */}
             {readingMode === 'flow' && (
@@ -590,6 +703,7 @@ export function VerseList() {
                           type="button"
                           onClick={(e) => {
                             e.stopPropagation()
+                            selectVerse(verse.id)
                             openStudyPanel(verse.id)
                           }}
                           className="inline-flex align-super mx-[2px] text-accent/70 hover:text-accent"
@@ -664,6 +778,7 @@ export function VerseList() {
                           type="button"
                           onClick={(e) => {
                             e.stopPropagation()
+                            selectVerse(verse.id)
                             openStudyPanel(verse.id)
                           }}
                           className="shrink-0 self-start mt-1 inline-flex h-6 w-6 items-center justify-center rounded-md text-accent/70 hover:text-accent hover:bg-bg-tertiary"

--- a/src/lib/noteTypes.tsx
+++ b/src/lib/noteTypes.tsx
@@ -1,0 +1,115 @@
+import type { JSX } from 'react'
+
+export type NoteType = 'note' | 'prayer' | 'insight' | 'question' | 'application'
+
+export interface NoteTypeDef {
+  type: NoteType
+  labelKey: string
+  icon: () => JSX.Element
+  bgClass: string
+  borderClass: string
+  indicatorClass: string
+  italic: boolean
+}
+
+function PrayerIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6z" />
+      <path d="M12 5V3m0 2a7 7 0 0 0-7 7v2a7 7 0 0 1 7 3 7 7 0 0 1 7-3v-2a7 7 0 0 0-7-7z" />
+      <path d="M5 12a7 7 0 0 0-3 4m17-4a7 7 0 0 1 3 4" />
+    </svg>
+  )
+}
+
+function InsightIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 17h4v4h-4z" />
+      <path d="M12 3v4" />
+      <path d="M12 7a5 5 0 0 1 5 5v3H7v-3a5 5 0 0 1 5-5z" />
+      <path d="M8 12h.01M12 12h.01M16 12h.01" />
+    </svg>
+  )
+}
+
+function QuestionIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  )
+}
+
+function ApplicationIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  )
+}
+
+function NoteIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+    </svg>
+  )
+}
+
+export const NOTE_TYPES: Record<NoteType, NoteTypeDef> = {
+  note: {
+    type: 'note',
+    labelKey: 'notes.typeNote',
+    icon: NoteIcon,
+    bgClass: '',
+    borderClass: 'border-l-accent/30',
+    indicatorClass: 'text-accent/60',
+    italic: false,
+  },
+  prayer: {
+    type: 'prayer',
+    labelKey: 'notes.typePrayer',
+    icon: PrayerIcon,
+    bgClass: 'bg-[#c792ea10]',
+    borderClass: 'border-l-[#c792ea]',
+    indicatorClass: 'text-[#c792ea]',
+    italic: true,
+  },
+  insight: {
+    type: 'insight',
+    labelKey: 'notes.typeInsight',
+    icon: InsightIcon,
+    bgClass: 'bg-[#61afef10]',
+    borderClass: 'border-l-[#61afef]',
+    indicatorClass: 'text-[#61afef]',
+    italic: false,
+  },
+  question: {
+    type: 'question',
+    labelKey: 'notes.typeQuestion',
+    icon: QuestionIcon,
+    bgClass: 'bg-[#e5c07b10]',
+    borderClass: 'border-l-[#e5c07b]',
+    indicatorClass: 'text-[#e5c07b]',
+    italic: false,
+  },
+  application: {
+    type: 'application',
+    labelKey: 'notes.typeApplication',
+    icon: ApplicationIcon,
+    bgClass: 'bg-[#98c37910]',
+    borderClass: 'border-l-[#98c379]',
+    indicatorClass: 'text-[#98c379]',
+    italic: false,
+  },
+}
+
+export const NOTE_TYPE_LIST: NoteTypeDef[] = Object.values(NOTE_TYPES)
+
+export function getNoteTypeDef(type: NoteType | undefined): NoteTypeDef {
+  return NOTE_TYPES[type ?? 'note'] ?? NOTE_TYPES.note
+}

--- a/src/lib/store/useNoteStore.ts
+++ b/src/lib/store/useNoteStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { api } from '@/lib/api'
+import type { NoteType } from '@/lib/noteTypes'
 
 export interface Note {
   id: number
@@ -8,6 +9,7 @@ export interface Note {
   body: string
   created_at: string
   is_public: boolean
+  note_type?: NoteType
   user?: { id: number; name: string; email: string }
   likes_count?: number
   is_liked?: boolean
@@ -18,8 +20,9 @@ interface NoteState {
   notes: Record<number, Note[]>   // keyed by numeric verse id
   loading: Record<number, boolean>
   loadNotes: (verseApiId: number) => Promise<void>
-  addNote: (verseApiId: number, body: string, parentId?: number, isPublic?: boolean) => Promise<void>
+  addNote: (verseApiId: number, body: string, parentId?: number, isPublic?: boolean, noteType?: NoteType) => Promise<void>
   updateNote: (verseApiId: number, noteId: number, body: string) => Promise<void>
+  updateNoteType: (verseApiId: number, noteId: number, noteType: NoteType) => Promise<void>
   toggleNoteVisibility: (verseApiId: number, noteId: number) => Promise<void>
   deleteNote: (verseApiId: number, noteId: number) => Promise<void>
   likeNote: (verseApiId: number, noteId: number) => Promise<void>
@@ -43,15 +46,16 @@ export const useNoteStore = create<NoteState>((set, get) => ({
     }
   },
 
-  addNote: async (verseApiId, body, parentId, isPublic = false) => {
-    const note = await api.post<Note>(`/api/verses/${verseApiId}/notes`, { body, is_public: isPublic, parent_id: parentId ?? null })
+  addNote: async (verseApiId, body, parentId, isPublic = false, noteType = 'note') => {
+    const note = await api.post<Note>(`/api/verses/${verseApiId}/notes`, { body, is_public: isPublic, parent_id: parentId ?? null, note_type: noteType })
     set(s => ({
-      notes: { ...s.notes, [verseApiId]: [...(s.notes[verseApiId] ?? []), note] },
+      notes: { ...s.notes, [verseApiId]: [...(s.notes[verseApiId] ?? []), { ...note, note_type: note.note_type ?? noteType }] },
     }))
   },
 
   updateNote: async (verseApiId, noteId, body) => {
-    const updated = await api.patch<Note>(`/api/notes/${noteId}`, { body })
+    const current = get().notes[verseApiId]?.find(n => n.id === noteId)
+    const updated = await api.patch<Note>(`/api/notes/${noteId}`, { body, note_type: current?.note_type ?? 'note' })
     set(s => ({
       notes: {
         ...s.notes,
@@ -64,11 +68,21 @@ export const useNoteStore = create<NoteState>((set, get) => ({
     const current = get().notes[verseApiId]?.find(n => n.id === noteId)
     if (!current) return
     const next = !current.is_public
-    await api.patch(`/api/notes/${noteId}`, { is_public: next, body: current.body })
+    await api.patch(`/api/notes/${noteId}`, { is_public: next, body: current.body, note_type: current.note_type ?? 'note' })
     set(s => ({
       notes: {
         ...s.notes,
         [verseApiId]: s.notes[verseApiId]?.map(n => n.id === noteId ? { ...n, is_public: next } : n) ?? [],
+      },
+    }))
+  },
+
+  updateNoteType: async (verseApiId, noteId, noteType) => {
+    await api.patch(`/api/notes/${noteId}`, { note_type: noteType })
+    set(s => ({
+      notes: {
+        ...s.notes,
+        [verseApiId]: s.notes[verseApiId]?.map(n => n.id === noteId ? { ...n, note_type: noteType } : n) ?? [],
       },
     }))
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -100,6 +100,12 @@
   "notes.publishConfirm": "Click to publish",
   "notes.unpublishConfirm": "Click to unpublish",
   "notes.replyToHidden": "In reply to a hidden note",
+  "notes.typeNote": "Note",
+  "notes.typePrayer": "Prayer",
+  "notes.typeInsight": "Insight",
+  "notes.typeQuestion": "Question",
+  "notes.typeApplication": "Application",
+  "notes.settings": "Note settings",
 
   "study.title": "Study",
   "study.empty": "Select a verse to begin studying",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -100,6 +100,12 @@
   "notes.publishConfirm": "Clic otra vez para publicar",
   "notes.unpublishConfirm": "Clic otra vez para ocultar",
   "notes.replyToHidden": "En respuesta a una nota oculta",
+  "notes.typeNote": "Nota",
+  "notes.typePrayer": "Oración",
+  "notes.typeInsight": "Perspectiva",
+  "notes.typeQuestion": "Pregunta",
+  "notes.typeApplication": "Aplicación",
+  "notes.settings": "Ajustes de nota",
 
   "study.title": "Estudio",
   "study.empty": "Selecciona un versículo para estudiar",


### PR DESCRIPTION
## Summary
- Collaborative study canvas with Hocuspocus/Yjs CRDT sync
- Note types: prayer, insight, question, application, with visual indicators
- Multi-verse selection context menu with batch highlight/bookmark actions
- Brand logo component (inline + stacked variants)
- Auth modal redesign with brand logo
- Study panel close button
- Note type persistence via API
- Favicon added
- Various UX fixes (PresenceAvatars hook call order, verse select on panel open)