### PR TITLE
Add SEO foundation: router, dynamic meta, sitemap, static chapters, useBibleRouter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useBibleRouter } from '@/lib/hooks/useBibleRouter'
 import { PanelLayout } from '@/components/layout/PanelLayout'
 import { Sidebar } from '@/components/sidebar/Sidebar'
 import { VerseList } from '@/components/verse/VerseList'
@@ -32,21 +32,9 @@ import { checkForAppUpdates } from '@/lib/updater'
 const VISITED_STORAGE_KEY = 'verbum_has_visited'
 let hasLoggedStartupSettings = false
 
-function parseBibleUrl(pathname: string): { book: string; chapter: number; verse?: number } | null {
-  const match = pathname.match(/^\/bible\/([^/]+)(?:\/(\d+))?(?:\/(\d+))?/)
-  if (!match) return null
-  return {
-    book: match[1],
-    chapter: match[2] ? parseInt(match[2], 10) : 1,
-    verse: match[3] ? parseInt(match[3], 10) : undefined,
-  }
-}
-
 export default function App() {
+  const initialRoute = useBibleRouter()
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const location = useLocation()
-  const manualNav = useRef(false)
   const openCommandPalette = useUIStore(s => s.openCommandPalette)
   const activePanel        = useUIStore(s => s.activePanel)
   const commentaryOpen     = useUIStore(s => s.commentaryOpen)
@@ -58,9 +46,6 @@ export default function App() {
   const versions = useVerseStore(s => s.versions)
   const versionId = useVerseStore(s => s.versionId)
   const selectedBook = useVerseStore(s => s.selectedBook)
-  const selectedChapter = useVerseStore(s => s.selectedChapter)
-  const selectedVerseId = useVerseStore(s => s.selectedVerseId)
-  const books = useVerseStore(s => s.books)
   const locale = useUIStore(s => s.locale)
   const authInit = useAuthStore(s => s.init)
   const user = useAuthStore(s => s.user)
@@ -79,7 +64,6 @@ export default function App() {
   const studyWsToken = useStudyStore(s => s.wsToken)
 
   useEffect(() => {
-    const initialRoute = parseBibleUrl(window.location.pathname)
     void (async () => {
       await authInit()
       await loadBooks(initialRoute ?? undefined)
@@ -101,42 +85,6 @@ export default function App() {
       window.history.replaceState({}, '', window.location.pathname)
     }
   }, [openAuthModalFunc])
-
-  // Sync store navigation to URL
-  useEffect(() => {
-    if (!selectedBook) return
-
-    let path = `/bible/${selectedBook}/${selectedChapter}`
-    if (selectedVerseId) {
-      const parts = selectedVerseId.split('-')
-      if (parts.length >= 3) {
-        path += `/${parts[2]}`
-      }
-    }
-
-    if (window.location.pathname !== path) {
-      manualNav.current = true
-      navigate(path, { replace: true })
-    }
-  }, [selectedBook, selectedChapter, selectedVerseId, navigate])
-
-  // Handle browser back/forward: URL → store
-  useEffect(() => {
-    if (manualNav.current) {
-      manualNav.current = false
-      return
-    }
-    const route = parseBibleUrl(location.pathname)
-    if (!route || books.length === 0) return
-    const state = useVerseStore.getState()
-    if (route.book !== state.selectedBook || route.chapter !== state.selectedChapter) {
-      if (route.verse) {
-        state.openVerse(route.book, route.chapter, route.verse)
-      } else {
-        state.loadChapter(route.book, route.chapter)
-      }
-    }
-  }, [location.pathname, books.length])
 
   useEffect(() => {
     if (hasLoggedStartupSettings || !selectedBook) return

--- a/src/lib/hooks/useBibleRouter.ts
+++ b/src/lib/hooks/useBibleRouter.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+import { useVerseStore } from '@/lib/store/useVerseStore'
+
+function parseBibleUrl(pathname: string): { book: string; chapter: number; verse?: number } | null {
+  const match = pathname.match(/^\/bible\/([^/]+)(?:\/(\d+))?(?:\/(\d+))?/)
+  if (!match) return null
+  return {
+    book: match[1],
+    chapter: match[2] ? parseInt(match[2], 10) : 1,
+    verse: match[3] ? parseInt(match[3], 10) : undefined,
+  }
+}
+
+function buildPath(book: string, chapter: number, verseId: string | null): string {
+  let path = `/bible/${book}/${chapter}`
+  if (verseId) {
+    const parts = verseId.split('-')
+    if (parts.length >= 3) path += `/${parts[2]}`
+  }
+  return path
+}
+
+export function useBibleRouter() {
+  const programmaticNav = useRef(false)
+
+  // Store → URL sync via Zustand subscribe (fires synchronously on set())
+  useEffect(() => {
+    let prevBook = ''
+    let prevChapter = 0
+    let prevVerseId = ''
+
+    const unsub = useVerseStore.subscribe((state) => {
+      const { selectedBook, selectedChapter, selectedVerseId } = state
+      if (!selectedBook) return
+
+      if (selectedBook === prevBook && selectedChapter === prevChapter && selectedVerseId === prevVerseId) return
+      prevBook = selectedBook
+      prevChapter = selectedChapter
+      prevVerseId = selectedVerseId ?? ''
+
+      const path = buildPath(selectedBook, selectedChapter, selectedVerseId)
+      if (window.location.pathname === path) return
+
+      programmaticNav.current = true
+      window.history.replaceState(null, '', path)
+    })
+
+    return unsub
+  }, [])
+
+  // Browser back/forward → Store via popstate
+  useEffect(() => {
+    const handlePopstate = () => {
+      if (programmaticNav.current) {
+        programmaticNav.current = false
+        return
+      }
+      const route = parseBibleUrl(window.location.pathname)
+      if (!route) return
+      const state = useVerseStore.getState()
+      if (state.books.length === 0) return
+      if (route.book !== state.selectedBook || route.chapter !== state.selectedChapter) {
+        if (route.verse) {
+          state.openVerse(route.book, route.chapter, route.verse)
+        } else {
+          state.loadChapter(route.book, route.chapter)
+        }
+      }
+    }
+
+    window.addEventListener('popstate', handlePopstate)
+    return () => window.removeEventListener('popstate', handlePopstate)
+  }, [])
+
+  // Parse URL on mount so caller can use it for initial load
+  return parseBibleUrl(window.location.pathname)
+}


### PR DESCRIPTION
## Summary
- **Router & URL sync**: `react-router-dom` v7 with `BrowserRouter`. Two-way store↔URL sync via `useBibleRouter` hook using Zustand `subscribe()` + native `history.replaceState`.
- **Dynamic head management**: `react-helmet-async` + `<SEOMeta />` in `VerseList`. Per-route title, description, canonical URL, OG/Twitter tags, and JSON-LD `BreadcrumbList` + `WebPage`.
- **Static chapter pages**: 1255 HTML files with full verse content, meta tags, and JSON-LD generated from the public API at build time.
- **Sitemap & robots.txt**: Auto-generated sitemap (1256 URLs) from API, robots.txt allowing full crawl.
- **Static head fallback**: `index.html` includes base OG/Twitter/JSON-LD (`Organization` + `WebApplication` schema).
- **Build separation**: `pnpm build` (Tauri/desktop, no API calls) vs `pnpm build:web` (SEO-ready web build).