### PR TITLE
fix: evitar que el botón de tres puntos en mobile cambie la selección de versículos

### DIFF
--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -442,7 +442,6 @@ export function VerseList() {
     if (selectedVerseIds.includes(verse.id) && selectedVerseIds.length > 1) {
       openMenu(rect.right - 12, rect.bottom + 8, buildMultiVerseMenu())
     } else {
-      selectVerse(verse.id)
       openMenu(rect.right - 12, rect.bottom + 8, buildVerseMenu(verse))
     }
   }


### PR DESCRIPTION
## Summary
- Al tocar el botón de tres puntos (`IconMore`) en mobile, se ejecutaban dos acciones: seleccionar el versículo y abrir el menú contextual. Esto interfería con la funcionalidad de selección existente.
- Se eliminó la llamada a `selectVerse(verse.id)` dentro de `openVerseMenuFromButton`, para que el botón solo abra el menú sin alterar la selección.