### PR TITLE
Refactor router + study canvas polish (resize, undo/redo, scroll)

### DIFF
--- a/src/components/study/StudyCanvas.tsx
+++ b/src/components/study/StudyCanvas.tsx
@@ -535,6 +535,21 @@ function StudyCanvasInner({
   }, [isGuest]);
 
   useEffect(() => {
+    if (isGuest) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key !== 'z' && e.key !== 'Z') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName))) return;
+      e.preventDefault();
+      if (e.shiftKey) redo();
+      else undo();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, redo, isGuest]);
+
+  useEffect(() => {
     (window as any).__studyCanvasActions = { addStickyNote, addVerseNode, addPassageNode, undo, redo, zoomIn, zoomOut, fitView, toggleLock };
     (window as any).__studyCanvasState = { isLocked: !isInteractive };
     return () => { delete (window as any).__studyCanvasActions; delete (window as any).__studyCanvasState; };
@@ -642,6 +657,7 @@ function StudyCanvasInner({
           selectionKeyCode="Shift"
           className="bg-bg-secondary"
           defaultEdgeOptions={{ type: 'default', animated: false }}
+          proOptions={{ hideAttribution: true }}
           panOnDrag={tool === 'hand' || isGuest ? [0, 1] : [1]}
           nodesDraggable={!isGuest && tool === 'select'}
           nodesConnectable={!isGuest && tool === 'select'}

--- a/src/components/study/StudyCanvas.tsx
+++ b/src/components/study/StudyCanvas.tsx
@@ -308,7 +308,9 @@ function StudyCanvasInner({
     const nodesMap = getNodesMap(doc);
     const edgesMap = getEdgesMap(doc);
     if (!isGuest) {
-      undoManagerRef.current = new Y.UndoManager([nodesMap, edgesMap]);
+      undoManagerRef.current = new Y.UndoManager([nodesMap, edgesMap], {
+        trackedOrigins: new Set([null, 'local']),
+      });
     }
 
     const syncFromYjs = (_events: any[], transaction: any) => {

--- a/src/components/study/StudyCanvas.tsx
+++ b/src/components/study/StudyCanvas.tsx
@@ -70,6 +70,8 @@ function getCanvasSnapshotSignature(nodes: Node[], edges: Edge[]) {
         id: node.id,
         type: node.type,
         position: node.position,
+        width: (node as any).width,
+        height: (node as any).height,
         data: stripEphemeralNodeData(node.data),
       }))
       .sort((a, b) => a.id.localeCompare(b.id)),
@@ -314,8 +316,6 @@ function StudyCanvasInner({
     }
 
     const syncFromYjs = (_events: any[], transaction: any) => {
-      if (transaction?.origin === 'local') return;
-
       const currentNodes: Node[] = [];
       nodesMap.forEach((nodeMap, id) => {
         const node = nodeFromYMap(id, nodeMap);
@@ -331,6 +331,15 @@ function StudyCanvasInner({
       });
 
       const signature = getCanvasSnapshotSignature(currentNodes, currentEdges);
+
+      // Local writes: React state is already up to date via onNodesChange.
+      // Just keep the signature ref fresh so a later undo (origin=UndoManager)
+      // sees a real diff and triggers applyRemoteSnapshot.
+      if (transaction?.origin === 'local') {
+        yjsSnapshotSignatureRef.current = signature;
+        return;
+      }
+
       if (signature === yjsSnapshotSignatureRef.current) return;
 
       yjsSnapshotSignatureRef.current = signature;
@@ -424,6 +433,12 @@ function StudyCanvasInner({
         for (const change of changes) {
           if (change.type === 'position' && change.position) {
             schedulePositionWrite(change.id, { x: change.position.x, y: change.position.y });
+          } else if (change.type === 'dimensions' && change.dimensions && change.resizing === false) {
+            const existing = nodesMap.get(change.id);
+            if (existing) {
+              existing.set('width', Math.round(change.dimensions.width));
+              existing.set('height', Math.round(change.dimensions.height));
+            }
           } else if (change.type === 'remove') {
             pendingPositionWritesRef.current.delete(change.id);
             nodesMap.delete(change.id);
@@ -536,26 +551,28 @@ function StudyCanvasInner({
     undoManagerRef.current?.redo();
   }, [isGuest]);
 
-  useEffect(() => {
+  const resizeNode = useCallback((id: string, width: number, height: number) => {
     if (isGuest) return;
-    const handler = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      if (e.key !== 'z' && e.key !== 'Z') return;
-      const target = e.target as HTMLElement | null;
-      if (target && (target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName))) return;
-      e.preventDefault();
-      if (e.shiftKey) redo();
-      else undo();
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [undo, redo, isGuest]);
+    const d = docRef.current;
+    if (!d) return;
+    const w = Math.round(width);
+    const h = Math.round(height);
+    d.transact(() => {
+      const nodesMap = getNodesMap(d);
+      const existing = nodesMap.get(id);
+      if (!existing) return;
+      existing.set('width', w);
+      existing.set('height', h);
+    }, 'local');
+    setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, width: w, height: h } : n)));
+    undoManagerRef.current?.stopCapturing();
+  }, [isGuest]);
 
-  useEffect(() => {
-    (window as any).__studyCanvasActions = { addStickyNote, addVerseNode, addPassageNode, undo, redo, zoomIn, zoomOut, fitView, toggleLock };
+useEffect(() => {
+    (window as any).__studyCanvasActions = { addStickyNote, addVerseNode, addPassageNode, undo, redo, resizeNode, zoomIn, zoomOut, fitView, toggleLock };
     (window as any).__studyCanvasState = { isLocked: !isInteractive };
     return () => { delete (window as any).__studyCanvasActions; delete (window as any).__studyCanvasState; };
-  }, [addStickyNote, addVerseNode, addPassageNode, undo, redo, zoomIn, zoomOut, fitView, toggleLock, isInteractive]);
+  }, [addStickyNote, addVerseNode, addPassageNode, undo, redo, resizeNode, zoomIn, zoomOut, fitView, toggleLock, isInteractive]);
 
   // --- Cursor tracking ---
   const handleCanvasPointerMove = useCallback(
@@ -600,6 +617,7 @@ function StudyCanvasInner({
       if (isGuest) return;
       handleCanvasPointerMove(event);
       flushPendingPositionWrites();
+      undoManagerRef.current?.stopCapturing();
       setLocalDragging(false);
       setLocalSelection(getSelectedNodeIds(node.id));
     },

--- a/src/components/study/StudyTopBar.tsx
+++ b/src/components/study/StudyTopBar.tsx
@@ -25,15 +25,29 @@ export function StudyTopBar({ users, isGuest }: { users: AwarenessUser[]; isGues
   const [showInvite, setShowInvite] = useState(false)
 
   const handleShare = useCallback(async () => {
-    const session = useStudyStore.getState().activeSession
-    let url = await generateShareLink()
-    if (!url && session) {
-      const token = useStudyStore.getState().shareToken
-      url = `${window.location.origin}${paths.study({ sessionId: session.id, shareToken: token })}`
-    }
-    if (url) {
+    try {
+      const session = useStudyStore.getState().activeSession
+      let url: string | null = null
+      try {
+        url = await generateShareLink()
+      } catch (err) {
+        console.warn('[StudyTopBar] generateShareLink failed, falling back', err)
+      }
+      if (!url && session) {
+        const token = useStudyStore.getState().shareToken
+        if (token) {
+          url = `${window.location.origin}${paths.study({ sessionId: session.id, shareToken: token })}`
+        }
+      }
+      if (!url) {
+        addToast('Could not create share link', 'error')
+        return
+      }
       await navigator.clipboard.writeText(url)
       addToast('Share link copied to clipboard', 'success')
+    } catch (err) {
+      console.error('[StudyTopBar] share failed', err)
+      addToast('Could not copy share link', 'error')
     }
   }, [generateShareLink, addToast])
 

--- a/src/components/study/nodes/CommentNode.tsx
+++ b/src/components/study/nodes/CommentNode.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
 import { cn } from '@/lib/cn';
 import { ResizableNode } from './ResizableNode';
+import { useNoWheelOnOverflow } from './useNoWheelOnOverflow';
 
 export type CommentNodeData = {
   authorName: string;
@@ -11,6 +12,7 @@ export type CommentNodeData = {
 type CommentNodeType = Node<CommentNodeData, 'comment'>;
 
 export function CommentNode({ id, data, selected }: NodeProps<CommentNodeType>) {
+  const { ref: scrollRef, className: scrollClass } = useNoWheelOnOverflow<HTMLParagraphElement>();
   return (
     <ResizableNode id={id} selected={selected} minWidth={200} minHeight={80}>
       <div
@@ -27,7 +29,7 @@ export function CommentNode({ id, data, selected }: NodeProps<CommentNodeType>) 
           <span className="text-xs font-medium text-text-primary">{data.authorName}</span>
           <span className="text-2xs text-text-muted ml-auto">{data.createdAt}</span>
         </div>
-        <p className="text-sm text-text-secondary overflow-auto flex-1">{data.text}</p>
+        <p ref={scrollRef} className={cn('text-sm text-text-secondary overflow-auto flex-1', scrollClass)}>{data.text}</p>
         <Handle type="source" position={Position.Bottom} className="!bg-border" />
       </div>
     </ResizableNode>

--- a/src/components/study/nodes/CommentNode.tsx
+++ b/src/components/study/nodes/CommentNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
 import { cn } from '@/lib/cn';
+import { ResizableNode } from './ResizableNode';
 
 export type CommentNodeData = {
   authorName: string;
@@ -9,24 +10,26 @@ export type CommentNodeData = {
 
 type CommentNodeType = Node<CommentNodeData, 'comment'>;
 
-export function CommentNode({ data, selected }: NodeProps<CommentNodeType>) {
+export function CommentNode({ id, data, selected }: NodeProps<CommentNodeType>) {
   return (
-    <div
-      className={cn(
-        'bg-surface border border-border rounded-lg p-3 min-w-[220px] max-w-[320px] shadow-sm',
-        selected && 'ring-2 ring-accent',
-      )}
-    >
-      <Handle type="target" position={Position.Top} className="!bg-border" />
-      <div className="flex items-center gap-2 mb-1.5">
-        <div className="w-5 h-5 rounded-full bg-accent/20 flex items-center justify-center text-2xs font-medium text-accent shrink-0">
-          {data.authorName.charAt(0).toUpperCase()}
+    <ResizableNode id={id} selected={selected} minWidth={200} minHeight={80}>
+      <div
+        className={cn(
+          'bg-surface border border-border rounded-lg p-3 shadow-sm w-full h-full flex flex-col overflow-hidden',
+          selected && 'ring-2 ring-accent',
+        )}
+      >
+        <Handle type="target" position={Position.Top} className="!bg-border" />
+        <div className="flex items-center gap-2 mb-1.5 shrink-0">
+          <div className="w-5 h-5 rounded-full bg-accent/20 flex items-center justify-center text-2xs font-medium text-accent shrink-0">
+            {data.authorName.charAt(0).toUpperCase()}
+          </div>
+          <span className="text-xs font-medium text-text-primary">{data.authorName}</span>
+          <span className="text-2xs text-text-muted ml-auto">{data.createdAt}</span>
         </div>
-        <span className="text-xs font-medium text-text-primary">{data.authorName}</span>
-        <span className="text-2xs text-text-muted ml-auto">{data.createdAt}</span>
+        <p className="text-sm text-text-secondary overflow-auto flex-1">{data.text}</p>
+        <Handle type="source" position={Position.Bottom} className="!bg-border" />
       </div>
-      <p className="text-sm text-text-secondary">{data.text}</p>
-      <Handle type="source" position={Position.Bottom} className="!bg-border" />
-    </div>
+    </ResizableNode>
   );
 }

--- a/src/components/study/nodes/PassageNode.tsx
+++ b/src/components/study/nodes/PassageNode.tsx
@@ -6,6 +6,7 @@ import { bibleApi } from '@/lib/bibleApi';
 import { StudyDocContext } from '@/lib/study/StudyDocContext';
 import { getNodesMap } from '@/lib/study/yDocHelpers';
 import { ResizableNode } from './ResizableNode';
+import { useNoWheelOnOverflow } from './useNoWheelOnOverflow';
 
 export type PassageNodeData = {
   bookSlug: string;
@@ -24,6 +25,7 @@ export function PassageNode({ id, data, selected }: NodeProps<PassageNodeType>) 
   const doc = useContext(StudyDocContext);
   const [loadFailed, setLoadFailed] = useState(false);
   const verses = data.verses ?? [];
+  const { ref: scrollRef, className: scrollClass } = useNoWheelOnOverflow<HTMLDivElement>();
 
   useEffect(() => {
     if (!doc || verses.length > 0 || !data.bookSlug || !data.chapter || !data.version_id) return;
@@ -82,7 +84,7 @@ export function PassageNode({ id, data, selected }: NodeProps<PassageNodeType>) 
         <div className="text-2xs text-accent uppercase tracking-wide mb-2 shrink-0">
           {data.reference}
         </div>
-        <div className="flex-1 overflow-y-auto space-y-1.5 pr-1 min-h-0">
+        <div ref={scrollRef} className={cn('flex-1 overflow-y-auto space-y-1.5 pr-1 min-h-0', scrollClass)}>
           {verses.length > 0 ? (
             verses.map((v) => (
               <div key={v.verse} className="flex gap-2 text-sm leading-relaxed">

--- a/src/components/study/nodes/PassageNode.tsx
+++ b/src/components/study/nodes/PassageNode.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/cn';
 import { bibleApi } from '@/lib/bibleApi';
 import { StudyDocContext } from '@/lib/study/StudyDocContext';
 import { getNodesMap } from '@/lib/study/yDocHelpers';
+import { ResizableNode } from './ResizableNode';
 
 export type PassageNodeData = {
   bookSlug: string;
@@ -70,33 +71,35 @@ export function PassageNode({ id, data, selected }: NodeProps<PassageNodeType>) 
   }, [doc, id, data, verses.length]);
 
   return (
-    <div
-      className={cn(
-        'bg-surface border border-border rounded-lg p-3 min-w-[300px] max-w-[450px] max-h-[400px] shadow-sm flex flex-col',
-        selected && 'ring-2 ring-accent',
-      )}
-    >
-      <Handle type="target" position={Position.Top} className="!bg-border" />
-      <div className="text-2xs text-accent uppercase tracking-wide mb-2 shrink-0">
-        {data.reference}
-      </div>
-      <div className="flex-1 overflow-y-auto space-y-1.5 pr-1">
-        {verses.length > 0 ? (
-          verses.map((v) => (
-            <div key={v.verse} className="flex gap-2 text-sm leading-relaxed">
-              <span className="text-2xs text-text-muted shrink-0 mt-0.5 w-4 text-right">
-                {v.verse}
-              </span>
-              <span className="text-text-primary">{v.text}</span>
-            </div>
-          ))
-        ) : loadFailed ? (
-          <p className="text-sm text-red-400">{t('study.passage.loadFailed')}</p>
-        ) : (
-          <p className="text-sm text-text-muted">{t('study.passage.loading')}</p>
+    <ResizableNode id={id} selected={selected} minWidth={260} minHeight={140}>
+      <div
+        className={cn(
+          'bg-surface border border-border rounded-lg p-3 shadow-sm w-full h-full flex flex-col',
+          selected && 'ring-2 ring-accent',
         )}
+      >
+        <Handle type="target" position={Position.Top} className="!bg-border" />
+        <div className="text-2xs text-accent uppercase tracking-wide mb-2 shrink-0">
+          {data.reference}
+        </div>
+        <div className="flex-1 overflow-y-auto space-y-1.5 pr-1 min-h-0">
+          {verses.length > 0 ? (
+            verses.map((v) => (
+              <div key={v.verse} className="flex gap-2 text-sm leading-relaxed">
+                <span className="text-2xs text-text-muted shrink-0 mt-0.5 w-4 text-right">
+                  {v.verse}
+                </span>
+                <span className="text-text-primary">{v.text}</span>
+              </div>
+            ))
+          ) : loadFailed ? (
+            <p className="text-sm text-red-400">{t('study.passage.loadFailed')}</p>
+          ) : (
+            <p className="text-sm text-text-muted">{t('study.passage.loading')}</p>
+          )}
+        </div>
+        <Handle type="source" position={Position.Bottom} className="!bg-border" />
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-border" />
-    </div>
+    </ResizableNode>
   );
 }

--- a/src/components/study/nodes/ResizableNode.tsx
+++ b/src/components/study/nodes/ResizableNode.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useRef, type ReactNode, type MouseEvent } from 'react';
+import { NodeResizer } from '@xyflow/react';
+import { cn } from '@/lib/cn';
+
+type ResizableNodeProps = {
+  id?: string;
+  selected?: boolean;
+  children: ReactNode;
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  /** Show resize handles only when node is selected (default true). */
+  onlyOnSelect?: boolean;
+  className?: string;
+};
+
+/**
+ * Generic resizable wrapper for study nodes.
+ *
+ * - Shows resize handles only when the node is selected (Linear-style).
+ * - Width/height changes are persisted by StudyCanvas via the
+ *   `dimensions` change in onNodesChange.
+ * - Double-click on the node body fits the node to its content.
+ */
+export function ResizableNode({
+  id,
+  selected,
+  children,
+  minWidth = 180,
+  minHeight = 80,
+  maxWidth,
+  maxHeight,
+  onlyOnSelect = true,
+  className,
+}: ResizableNodeProps) {
+  const isVisible = onlyOnSelect ? !!selected : true;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const handleDoubleClick = useCallback((e: MouseEvent) => {
+    if (!id) return;
+    // Don't fit-to-content when dbl-clicking inside an input/textarea or button.
+    const target = e.target as HTMLElement | null;
+    if (target && (target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(target.tagName))) return;
+
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    const nodeEl = wrapper.closest('.react-flow__node') as HTMLElement | null;
+    if (!nodeEl) return;
+
+    const prevW = nodeEl.style.width;
+    const prevH = nodeEl.style.height;
+    nodeEl.style.width = 'auto';
+    nodeEl.style.height = 'auto';
+    const measuredW = Math.max(minWidth, Math.ceil(nodeEl.offsetWidth));
+    const measuredH = Math.max(minHeight, Math.ceil(nodeEl.offsetHeight));
+    nodeEl.style.width = prevW;
+    nodeEl.style.height = prevH;
+
+    (window as any).__studyCanvasActions?.resizeNode?.(id, measuredW, measuredH);
+  }, [id, minWidth, minHeight]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn('relative w-full h-full', className)}
+      onDoubleClick={handleDoubleClick}
+    >
+      <NodeResizer
+        isVisible={isVisible}
+        minWidth={minWidth}
+        minHeight={minHeight}
+        maxWidth={maxWidth}
+        maxHeight={maxHeight}
+        lineStyle={{ borderWidth: 6, borderColor: 'transparent' }}
+        lineClassName="hover:!border-accent/60 transition-colors"
+        handleStyle={{ width: 12, height: 12, borderRadius: 3 }}
+        handleClassName="!bg-accent !border-2 !border-bg-primary"
+      />
+      {children}
+    </div>
+  );
+}

--- a/src/components/study/nodes/StickyNode.tsx
+++ b/src/components/study/nodes/StickyNode.tsx
@@ -1,15 +1,17 @@
 import { useContext, useEffect, useRef, useState, useCallback } from 'react';
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
 import { useTranslation } from 'react-i18next';
+import { Settings2 } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { StudyDocContext } from '@/lib/study/StudyDocContext';
 import { getNodesMap } from '@/lib/study/yDocHelpers';
+import { ResizableNode } from './ResizableNode';
 
 const STICKY_COLORS = [
-  { value: 'yellow', bg: 'bg-yellow-500/10 border-yellow-500/30', colorKey: 'study.colorYellow' },
-  { value: 'blue', bg: 'bg-blue-500/10 border-blue-500/30', colorKey: 'study.colorBlue' },
-  { value: 'green', bg: 'bg-green-500/10 border-green-500/30', colorKey: 'study.colorGreen' },
-  { value: 'pink', bg: 'bg-pink-500/10 border-pink-500/30', colorKey: 'study.colorPink' },
+  { value: 'yellow', bg: 'bg-yellow-500/10 border-yellow-500/30', swatch: 'bg-yellow-500', colorKey: 'study.colorYellow' },
+  { value: 'blue',   bg: 'bg-blue-500/10 border-blue-500/30',     swatch: 'bg-blue-500',   colorKey: 'study.colorBlue' },
+  { value: 'green',  bg: 'bg-green-500/10 border-green-500/30',   swatch: 'bg-green-500',  colorKey: 'study.colorGreen' },
+  { value: 'pink',   bg: 'bg-pink-500/10 border-pink-500/30',     swatch: 'bg-pink-500',   colorKey: 'study.colorPink' },
 ];
 
 export type StickyNodeData = {
@@ -25,9 +27,10 @@ export function StickyNode({ id, data, selected }: NodeProps<StickyNodeType>) {
 
   const [text, setText] = useState(data.text ?? '');
   const [color, setColor] = useState(data.color ?? 'yellow');
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const settingsRef = useRef<HTMLDivElement>(null);
 
-  // Listen to Yjs changes from other clients
   useEffect(() => {
     if (!doc) return;
     const nodesMap = getNodesMap(doc);
@@ -46,7 +49,6 @@ export function StickyNode({ id, data, selected }: NodeProps<StickyNodeType>) {
     };
   }, [doc, id]);
 
-  // Write local changes to Yjs (debounced for typing)
   const writeToYjs = useCallback(
     (newText: string, newColor: string) => {
       if (!doc) return;
@@ -76,54 +78,114 @@ export function StickyNode({ id, data, selected }: NodeProps<StickyNodeType>) {
     [text, writeToYjs],
   );
 
-  // Auto-resize textarea
-  useEffect(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-    }
-  }, [text]);
+useEffect(() => {
+    if (!settingsOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (!settingsRef.current?.contains(e.target as Node | null)) {
+        setSettingsOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onDown);
+    return () => window.removeEventListener('mousedown', onDown);
+  }, [settingsOpen]);
 
   const colorStyle = STICKY_COLORS.find((c) => c.value === color) ?? STICKY_COLORS[0];
 
   return (
+    <ResizableNode id={id} selected={selected} minWidth={180} minHeight={90}>
     <div
       className={cn(
-        'rounded-lg border shadow-sm min-w-[200px] max-w-[320px]',
+        'group/sticky relative rounded-lg border shadow-sm w-full h-full flex flex-col',
+        'cursor-grab active:cursor-grabbing transition-shadow',
         colorStyle.bg,
-        selected && 'ring-2 ring-accent',
+        selected && 'ring-2 ring-accent shadow-md',
       )}
     >
       <Handle type="target" position={Position.Top} className="!bg-border" />
+
+      {/* Drag handle bar */}
+      <div
+        className={cn(
+          'flex items-center justify-center h-4 rounded-t-lg',
+          'cursor-grab active:cursor-grabbing',
+          'opacity-0 group-hover/sticky:opacity-100 transition-opacity',
+          selected && 'opacity-100',
+        )}
+        title={t('study.sticky.dragHandle', 'Arrastrar')}
+      >
+        <div className="flex gap-0.5 opacity-50">
+          <span className="w-1 h-1 rounded-full bg-current" />
+          <span className="w-1 h-1 rounded-full bg-current" />
+          <span className="w-1 h-1 rounded-full bg-current" />
+          <span className="w-1 h-1 rounded-full bg-current" />
+        </div>
+      </div>
 
       <textarea
         ref={textareaRef}
         value={text}
         onChange={(e) => handleTextChange(e.target.value)}
-        className="w-full bg-transparent border-none outline-none resize-none text-sm text-text-primary p-3 placeholder:text-text-muted"
+        className="nodrag cursor-text flex-1 min-h-[60px] w-full bg-transparent border-none outline-none resize-none text-sm text-text-primary px-3 pb-3 pt-1 placeholder:text-text-muted leading-relaxed"
         placeholder={t('study.sticky.placeholder')}
-        rows={1}
       />
 
-      <div className="flex items-center gap-1 px-2 pb-2">
-        {STICKY_COLORS.map((c) => (
-          <button
-            key={c.value}
-            onClick={() => handleColorChange(c.value)}
+      {/* Settings button */}
+      <div
+        ref={settingsRef}
+        className={cn(
+          'nodrag absolute bottom-1.5 right-1.5',
+          'opacity-0 group-hover/sticky:opacity-100 focus-within:opacity-100 transition-opacity',
+          (selected || settingsOpen) && 'opacity-100',
+        )}
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setSettingsOpen((o) => !o);
+          }}
+          className={cn(
+            'cursor-pointer flex items-center justify-center w-6 h-6 rounded-md',
+            'text-text-muted hover:text-text-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors',
+            settingsOpen && 'bg-black/5 dark:bg-white/10 text-text-primary',
+          )}
+          title={t('study.sticky.settings', 'Opciones')}
+          aria-label={t('study.sticky.settings', 'Opciones')}
+        >
+          <Settings2 className="w-3.5 h-3.5" />
+        </button>
+
+        {settingsOpen && (
+          <div
             className={cn(
-              'w-5 h-5 rounded-full border-2 transition-all',
-              c.value === 'yellow' && 'bg-yellow-500/80 border-yellow-500',
-              c.value === 'blue' && 'bg-blue-500/80 border-blue-500',
-              c.value === 'green' && 'bg-green-500/80 border-green-500',
-              c.value === 'pink' && 'bg-pink-500/80 border-pink-500',
-              color === c.value && 'ring-1 ring-text-primary ring-offset-1 ring-offset-bg-primary',
+              'absolute bottom-full right-0 mb-1.5 z-10',
+              'bg-surface border border-border rounded-lg shadow-lg',
+              'p-2 flex items-center gap-1.5',
             )}
-            title={t(c.colorKey)}
-          />
-        ))}
+          >
+            {STICKY_COLORS.map((c) => (
+              <button
+                key={c.value}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleColorChange(c.value);
+                }}
+                className={cn(
+                  'cursor-pointer w-5 h-5 rounded-full transition-transform hover:scale-110',
+                  c.swatch,
+                  color === c.value && 'ring-2 ring-text-primary ring-offset-2 ring-offset-surface',
+                )}
+                title={t(c.colorKey)}
+                aria-label={t(c.colorKey)}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       <Handle type="source" position={Position.Bottom} className="!bg-border" />
     </div>
+    </ResizableNode>
   );
 }

--- a/src/components/study/nodes/StickyNode.tsx
+++ b/src/components/study/nodes/StickyNode.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/cn';
 import { StudyDocContext } from '@/lib/study/StudyDocContext';
 import { getNodesMap } from '@/lib/study/yDocHelpers';
 import { ResizableNode } from './ResizableNode';
+import { useNoWheelOnOverflow } from './useNoWheelOnOverflow';
 
 const STICKY_COLORS = [
   { value: 'yellow', bg: 'bg-yellow-500/10 border-yellow-500/30', swatch: 'bg-yellow-500', colorKey: 'study.colorYellow' },
@@ -28,7 +29,7 @@ export function StickyNode({ id, data, selected }: NodeProps<StickyNodeType>) {
   const [text, setText] = useState(data.text ?? '');
   const [color, setColor] = useState(data.color ?? 'yellow');
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { ref: textareaRef, className: textareaWheelClass } = useNoWheelOnOverflow<HTMLTextAreaElement>();
   const settingsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -125,7 +126,7 @@ useEffect(() => {
         ref={textareaRef}
         value={text}
         onChange={(e) => handleTextChange(e.target.value)}
-        className="nodrag cursor-text flex-1 min-h-[60px] w-full bg-transparent border-none outline-none resize-none text-sm text-text-primary px-3 pb-3 pt-1 placeholder:text-text-muted leading-relaxed"
+        className={cn('nodrag cursor-text flex-1 min-h-[60px] w-full bg-transparent border-none outline-none resize-none text-sm text-text-primary px-3 pb-3 pt-1 placeholder:text-text-muted leading-relaxed', textareaWheelClass)}
         placeholder={t('study.sticky.placeholder')}
       />
 

--- a/src/components/study/nodes/VerseNode.tsx
+++ b/src/components/study/nodes/VerseNode.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
 import { useVerseStore } from '@/lib/store/useVerseStore';
 import { ResizableNode } from './ResizableNode';
+import { useNoWheelOnOverflow } from './useNoWheelOnOverflow';
 
 export type VerseNodeData = {
   verseId: number;
@@ -18,6 +19,7 @@ export function VerseNode({ id, data, selected }: NodeProps<VerseNodeType>) {
   const versions = useVerseStore((s) => s.versions);
 
   const versionName = versions.find((v) => v.id === data.version_id)?.abbreviation ?? '';
+  const { ref: scrollRef, className: scrollClass } = useNoWheelOnOverflow<HTMLDivElement>();
 
   return (
     <ResizableNode id={id} selected={selected} minWidth={240} minHeight={90}>
@@ -32,7 +34,7 @@ export function VerseNode({ id, data, selected }: NodeProps<VerseNodeType>) {
           {data.reference}
           {versionName && <span className="text-text-muted ml-1">({versionName})</span>}
         </div>
-        <div className="text-sm leading-relaxed text-text-primary overflow-auto flex-1">
+        <div ref={scrollRef} className={cn('text-sm leading-relaxed text-text-primary overflow-auto flex-1', scrollClass)}>
           {data.text || t('study.verseNode.loading')}
         </div>
         <Handle type="source" position={Position.Bottom} className="!bg-border" />

--- a/src/components/study/nodes/VerseNode.tsx
+++ b/src/components/study/nodes/VerseNode.tsx
@@ -2,6 +2,7 @@ import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
 import { useVerseStore } from '@/lib/store/useVerseStore';
+import { ResizableNode } from './ResizableNode';
 
 export type VerseNodeData = {
   verseId: number;
@@ -12,28 +13,30 @@ export type VerseNodeData = {
 
 type VerseNodeType = Node<VerseNodeData, 'verse'>;
 
-export function VerseNode({ data, selected }: NodeProps<VerseNodeType>) {
+export function VerseNode({ id, data, selected }: NodeProps<VerseNodeType>) {
   const { t } = useTranslation();
   const versions = useVerseStore((s) => s.versions);
 
   const versionName = versions.find((v) => v.id === data.version_id)?.abbreviation ?? '';
 
   return (
-    <div
-      className={cn(
-        'bg-surface border border-border rounded-lg p-3 min-w-[280px] max-w-[400px] shadow-sm',
-        selected && 'ring-2 ring-accent',
-      )}
-    >
-      <Handle type="target" position={Position.Top} className="!bg-border" />
-      <div className="text-2xs text-accent uppercase tracking-wide mb-1">
-        {data.reference}
-        {versionName && <span className="text-text-muted ml-1">({versionName})</span>}
+    <ResizableNode id={id} selected={selected} minWidth={240} minHeight={90}>
+      <div
+        className={cn(
+          'bg-surface border border-border rounded-lg p-3 shadow-sm w-full h-full flex flex-col overflow-hidden',
+          selected && 'ring-2 ring-accent',
+        )}
+      >
+        <Handle type="target" position={Position.Top} className="!bg-border" />
+        <div className="text-2xs text-accent uppercase tracking-wide mb-1">
+          {data.reference}
+          {versionName && <span className="text-text-muted ml-1">({versionName})</span>}
+        </div>
+        <div className="text-sm leading-relaxed text-text-primary overflow-auto flex-1">
+          {data.text || t('study.verseNode.loading')}
+        </div>
+        <Handle type="source" position={Position.Bottom} className="!bg-border" />
       </div>
-      <div className="text-sm leading-relaxed text-text-primary">
-        {data.text || t('study.verseNode.loading')}
-      </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-border" />
-    </div>
+    </ResizableNode>
   );
 }

--- a/src/components/study/nodes/useNoWheelOnOverflow.ts
+++ b/src/components/study/nodes/useNoWheelOnOverflow.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Returns a ref + className that adds ReactFlow's `nowheel` class only when
+ * the element actually overflows. Lets the canvas zoom freely on the wheel
+ * when there's nothing to scroll inside the node.
+ */
+export function useNoWheelOnOverflow<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [overflows, setOverflows] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const check = () => {
+      const next =
+        el.scrollHeight > el.clientHeight + 1 ||
+        el.scrollWidth > el.clientWidth + 1;
+      setOverflows((prev) => (prev === next ? prev : next));
+    };
+
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    const mo = new MutationObserver(check);
+    mo.observe(el, { childList: true, characterData: true, subtree: true });
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
+
+  return { ref, className: overflows ? 'nowheel' : '' };
+}

--- a/src/lib/defaultBibleVersion.test.ts
+++ b/src/lib/defaultBibleVersion.test.ts
@@ -3,9 +3,11 @@ import { selectDefaultBibleVersionId } from './defaultBibleVersion'
 import type { ApiVersion } from './bibleApi'
 
 const versions: ApiVersion[] = [
-  { id: 1, abbreviation: 'KJV', name: 'King James Version', language: 'en' },
+  { id: 1, abbreviation: 'ASV', name: 'American Standard Version', language: 'en' },
   { id: 2, abbreviation: 'RVR09', name: 'Reina-Valera 1909', language: 'es' },
   { id: 3, abbreviation: 'RVR60', name: 'Reina-Valera 1960', language: 'es' },
+  { id: 4, abbreviation: 'KJV', name: 'King James Version', language: 'en' },
+  { id: 5, abbreviation: 'AKJV', name: 'American KJV', language: 'en' },
 ]
 
 describe('selectDefaultBibleVersionId', () => {
@@ -13,8 +15,13 @@ describe('selectDefaultBibleVersionId', () => {
     expect(selectDefaultBibleVersionId(versions, 'es-ES')).toBe(3)
   })
 
-  it('uses an available English version for English browsers', () => {
-    expect(selectDefaultBibleVersionId(versions, 'en-US')).toBe(1)
+  it('prefers KJV for English browsers, even when it is not first in the list', () => {
+    expect(selectDefaultBibleVersionId(versions, 'en-US')).toBe(4)
+  })
+
+  it('does not pick AKJV when KJV is not available', () => {
+    const noKjv = versions.filter(v => v.abbreviation !== 'KJV')
+    expect(selectDefaultBibleVersionId(noKjv, 'en-US')).toBe(1)
   })
 
   it('falls back to the first available version for unsupported languages', () => {

--- a/src/lib/defaultBibleVersion.ts
+++ b/src/lib/defaultBibleVersion.ts
@@ -29,7 +29,7 @@ export function selectDefaultBibleVersionId(
   }
 
   if (languageCode === 'en') {
-    return byLanguage[0]?.id ?? versions[0].id
+    return byLanguage.find(isKingJamesVersion)?.id ?? byLanguage[0]?.id ?? versions[0].id
   }
 
   return byLanguage[0]?.id ?? versions[0].id
@@ -46,4 +46,12 @@ function isReinaValera1960(version: ApiVersion): boolean {
     value.includes('1960') &&
     (value.includes('reina') || value.includes('valera') || value.includes('rvr') || value.includes('rv60'))
   )
+}
+
+function isKingJamesVersion(version: ApiVersion): boolean {
+  const abbr = version.abbreviation.toLowerCase()
+  const name = version.name.toLowerCase()
+
+  // Match KJV but exclude variants like AKJV (American KJV) or NKJV.
+  return abbr === 'kjv' || (name.includes('king james') && !name.includes('american') && !name.includes('new king james'))
 }

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { api, setToken, clearToken } from '@/lib/api'
 import { applyUserSettings, fetchUserSettings, persistClientSettings } from '@/lib/userSettings'
+import { hydrateUserSession, resetUserSession } from '@/lib/userSession'
 
 interface AuthUser {
   id: number
@@ -32,6 +33,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       const settings = await fetchUserSettings()
       await applyUserSettings(settings)
       set({ user, loading: false })
+      void hydrateUserSession()
     } catch {
       clearToken()
       set({ loading: false })
@@ -41,15 +43,19 @@ export const useAuthStore = create<AuthState>((set) => ({
   login: async (email, password) => {
     const { token, user } = await api.post<{ token: string; user: AuthUser }>('/api/auth/login', { email, password })
     setToken(token)
+    resetUserSession()
     await persistClientSettings()
     set({ user })
+    void hydrateUserSession()
   },
 
   register: async (name, email, password) => {
     const { token, user } = await api.post<{ token: string; user: AuthUser }>('/api/auth/register', { name, email, password })
     setToken(token)
+    resetUserSession()
     await persistClientSettings()
     set({ user })
+    void hydrateUserSession()
   },
 
   forgotPassword: async (email) => {
@@ -69,6 +75,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     await api.post('/api/auth/logout', {}).catch(() => {})
     clearToken()
     localStorage.removeItem('verbum_last_reading')
+    resetUserSession()
     set({ user: null })
   },
 
@@ -76,6 +83,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     await api.delete('/api/user', { password })
     clearToken()
     localStorage.removeItem('verbum_last_reading')
+    resetUserSession()
     set({ user: null })
   },
 }))

--- a/src/lib/study/yDocHelpers.ts
+++ b/src/lib/study/yDocHelpers.ts
@@ -9,12 +9,17 @@ export function getEdgesMap(doc: Y.Doc): Y.Map<Y.Map<any>> {
 }
 
 export function nodeFromYMap(id: string, m: Y.Map<any>) {
-  return {
+  const node: any = {
     id: m.get('id') ?? id,
     type: m.get('type') ?? 'sticky',
     position: m.get('position') ?? { x: 0, y: 0 },
     data: m.get('data') ?? {},
   };
+  const width = m.get('width');
+  const height = m.get('height');
+  if (typeof width === 'number') node.width = width;
+  if (typeof height === 'number') node.height = height;
+  return node;
 }
 
 export function edgeFromYMap(id: string, m: Y.Map<any>) {
@@ -27,12 +32,14 @@ export function edgeFromYMap(id: string, m: Y.Map<any>) {
   };
 }
 
-export function writeNodeToMap(nodesMap: Y.Map<Y.Map<any>>, node: { id: string; type?: string; position?: { x: number; y: number }; data?: any }) {
+export function writeNodeToMap(nodesMap: Y.Map<Y.Map<any>>, node: { id: string; type?: string; position?: { x: number; y: number }; data?: any; width?: number; height?: number }) {
   const nodeMap = nodesMap.get(node.id) ?? new Y.Map();
   nodeMap.set('id', node.id);
   if (node.type) nodeMap.set('type', node.type);
   if (node.position) nodeMap.set('position', node.position);
   if (node.data) nodeMap.set('data', node.data);
+  if (typeof node.width === 'number') nodeMap.set('width', node.width);
+  if (typeof node.height === 'number') nodeMap.set('height', node.height);
   nodesMap.set(node.id, nodeMap);
 }
 

--- a/src/lib/userSession.ts
+++ b/src/lib/userSession.ts
@@ -1,0 +1,45 @@
+import { useFriendStore } from '@/lib/store/useFriendStore'
+import { useBookmarkStore } from '@/lib/store/useBookmarkStore'
+import { useNotificationStore } from '@/lib/store/useNotificationStore'
+import { useStudyStore } from '@/lib/store/useStudyStore'
+import { useChatStore } from '@/lib/store/useChatStore'
+import { useNoteStore } from '@/lib/store/useNoteStore'
+import { useHighlightStore } from '@/lib/store/useHighlightStore'
+import { useActivityStore } from '@/lib/store/useActivityStore'
+
+// Pre-loads everything tied to the current account so the app feels populated
+// the moment a user logs in instead of trickling data in per-screen.
+export async function hydrateUserSession(): Promise<void> {
+  await Promise.allSettled([
+    useFriendStore.getState().load(),
+    useBookmarkStore.getState().load(),
+    useNotificationStore.getState().load(),
+    useStudyStore.getState().loadMyStudies(),
+    useStudyStore.getState().loadInvitations(),
+    useChatStore.getState().load(),
+  ])
+}
+
+// Wipes every account-scoped store so a previous user's data never leaks
+// across a logout / account switch.
+export function resetUserSession(): void {
+  useFriendStore.setState({
+    friends: [],
+    received: [],
+    sent: [],
+    searchResults: [],
+    isSearching: false,
+  })
+  useBookmarkStore.setState({
+    bookmarks: [],
+    bookmarkedIds: new Set(),
+    loading: false,
+  })
+  useNotificationStore.setState({ notifications: [] })
+  useStudyStore.getState().clearSession()
+  useStudyStore.setState({ myStudies: [], pendingInvitations: [] })
+  useChatStore.getState().reset()
+  useNoteStore.setState({ notes: {}, loading: {} })
+  useHighlightStore.setState({ highlights: {}, loading: {} })
+  useActivityStore.getState().clearAll()
+}


### PR DESCRIPTION
## Summary
- Replace ad-hoc routing with a centralized router
- Default English readers to KJV; hydrate/reset account-scoped stores on auth changes
- Toast feedback on share-link copy failure; default Firebase project
- Study canvas: resizable nodes (drag handles + double-click fit-to-content), undo/redo with Y.UndoManager, hide ReactFlow attribution, sticky restyle (settings popover instead of always-on color row), scroll-only-on-overflow wheel handling

## Test plan
- [ ] App boots and routes work end-to-end on the new router
- [ ] English users see KJV by default
- [ ] Login/logout swaps account-scoped state cleanly
- [ ] Share link copy fallback shows toast on failure
- [ ] Study canvas: drag, resize, double-click to fit content, Cmd+Z / Cmd+Shift+Z, wheel scrolls inside overflowing nodes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)