### PR TITLE
Send user's locale when fetching chapter commentary

### DIFF
--- a/src/components/reading/CommentaryPanel.tsx
+++ b/src/components/reading/CommentaryPanel.tsx
@@ -16,7 +16,7 @@ export function CommentaryPanel() {
   const [error, setError]           = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
 
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const bookName = books.find((b) => b.slug === selectedBook)?.name ?? selectedBook
 
   useEffect(() => {
@@ -24,11 +24,11 @@ export function CommentaryPanel() {
     setLoading(true)
     setError(false)
     setCommentary(null)
-    commentaryApi.get(selectedBook, selectedChapter)
+    commentaryApi.get(selectedBook, selectedChapter, i18n.language)
       .then(setCommentary)
       .catch(() => setError(true))
       .finally(() => setLoading(false))
-  }, [selectedBook, selectedChapter])
+  }, [selectedBook, selectedChapter, i18n.language])
 
   // Attach native click handlers to every external link after HTML renders
   useEffect(() => {

--- a/src/lib/commentaryApi.ts
+++ b/src/lib/commentaryApi.ts
@@ -6,9 +6,12 @@ export interface Commentary {
   chapter: number
   content: string
   scraped_at: string
+  locale: 'en' | 'es'
 }
 
 export const commentaryApi = {
-  get: (bookSlug: string, chapter: number) =>
-    api.get<Commentary>(`/api/commentary/${bookSlug}/${chapter}`),
+  get: (bookSlug: string, chapter: number, locale: string) => {
+    const lang = locale.startsWith('es') ? 'es' : 'en'
+    return api.get<Commentary>(`/api/commentary/${bookSlug}/${chapter}?locale=${lang}`)
+  },
 }


### PR DESCRIPTION
## Summary
- Pass `i18n.language` to `commentaryApi.get` so the request hits `/api/commentary/{book}/{ch}?locale=es|en`.
- Re-fetch the panel when the user toggles app locale (language added to the `useEffect` dep array).
- Normalize any `es-*` tag (e.g. `es-ES`, `es-419`) to `es`; everything else falls through to `en`.

Pairs with backend [freddysae0/bible@8b4ec16](https://github.com/freddysae0/bible/commit/8b4ec16) which adds `content_es` to `chapter_commentaries` and teaches `CommentaryController::show` to read `?locale=`.

## Test plan
- [ ] App in Spanish: open a chapter, commentary renders Guzik in Spanish (verify the heading is "Génesis 1" rather than "Genesis 1").
- [ ] App in English: same chapter renders the original English commentary.
- [ ] Toggle locale in Settings while the panel is open: it refetches and swaps language without a page reload.
- [ ] Network tab shows `?locale=es` / `?locale=en` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)