### PR TITLE
Sync frontend CLAUDE.md and fix stale README facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Tulia
+
+Spanish-first social Bible reading app. Read the Bible *with others* — friends, comments, shared feed, reading presence.
+
+**Design**: keyboard-first, minimalist, Linear-style. Every action should be reachable by keyboard; favor command palettes, shortcuts, and dense-but-quiet UI over mouse-driven affordances. Visual language follows Linear: restrained typography, subtle borders, generous whitespace, no decorative chrome.
+
+Name comes from *Tertulia* (Spanish: a social gathering to discuss books/ideas). Domain: `tulia.study`.
+
+## Layout
+
+This folder contains both halves of the product. Claude is invoked from here so it can see and edit across both.
+
+- `backend/` — Laravel + Livewire + Alpine + Tailwind. Local: `https://verbum.test` via Herd (symlink in `~/Library/Application Support/Herd/config/valet/Sites/verbum`). Prod: `https://tulia.study`. SQLite at `backend/database/database.sqlite` (absolute path in `.env`).
+- `frontend/` — Tauri 2 desktop/mobile + Vite + React 18 + TypeScript + Tailwind. Package name `tulia-study`. Web build deploys to Firebase Hosting at `https://bible.tulia.study` (`pnpm deploy`). Talks to the backend over HTTP and to a Hocuspocus collab server (JWT-authed) for shared study sessions.
+
+## Common commands
+
+Backend (`backend/`):
+- Browse: `https://verbum.test`
+- Artisan: use Herd's PHP — Herd sets it on PATH in its shells.
+
+Frontend (`frontend/`):
+- `pnpm dev` — Vite dev server
+- `pnpm tauri:dev` — Tauri desktop dev
+- `pnpm build:web` / `pnpm deploy` — web build + Firebase deploy
+- `pnpm test` — Vitest
+
+## Notes for Claude
+
+- Treat `backend/` and `frontend/` as one product. Cross-cutting changes (auth, session protocol, API shape) usually need edits in both.
+- When editing the backend's `.env`, keep `DB_DATABASE` as an absolute path — Laravel's SQLite driver requires it.
+- The Herd symlink target is the absolute path to `backend/`. If this folder ever moves again, update the symlink and `DB_DATABASE`.
+- Rust build artifacts under `frontend/src-tauri/target/` contain hardcoded absolute paths; they regenerate on rebuild — don't hand-edit.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ tulia.study is the app I wished existed.
 | UI | React + TypeScript + Tailwind |
 | State | Zustand |
 | Desktop | Tauri 2 (Rust + WebView2) |
-| Backend | Laravel 13 API |
-| Realtime | Laravel Reverb (WebSockets) |
+| Backend | Laravel API (separate repo) |
+| Collab | Hocuspocus (Yjs) for shared study sessions |
+| Broadcasting | Laravel Reverb |
 | Build | Vite + pnpm |
 
 ---
@@ -60,16 +61,16 @@ pnpm install
 # Web only (port 1420)
 pnpm dev
 
-# Desktop with hot reload — run in PowerShell
+# Desktop with hot reload
 pnpm tauri:dev
 
 # Build desktop binary
 pnpm tauri:build
 ```
 
-> On Windows, always run Tauri commands in PowerShell — the Rust/cargo PATH is not available in Git Bash.
+> On Windows, run Tauri commands in PowerShell — the Rust/cargo PATH isn't picked up in Git Bash.
 
-The backend (`verbum`) runs separately on port 8000. Set `VITE_API_URL` in `.env.local` to point to your local instance.
+The backend lives in a separate repo and is served locally at `https://verbum.test` via [Herd](https://herd.laravel.com/) (macOS). Set `VITE_API_URL=https://verbum.test` in `.env.local` to point at it.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `frontend/CLAUDE.md` mirroring the workspace root so any agent invoked from `frontend/` sees the same product context.
- README: replace "Laravel 13 API" + "Laravel Reverb (WebSockets)" with the actual stack (Hocuspocus for the study canvas + Reverb for broadcasting); fix the local backend URL from `port 8000` to `https://verbum.test` (Herd).

## Test plan
- [ ] README reads correctly on GitHub
- [ ] Stack table shows Collab + Broadcasting rows
🤖 Generated with [Claude Code](https://claude.com/claude-code)