### PR TITLE
Guided tour for first-time users

### DIFF
--- a/src/components/tutorial/TutorialInvite.tsx
+++ b/src/components/tutorial/TutorialInvite.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useTutorialStore } from '@/lib/store/useTutorialStore'
+
+export function TutorialInvite() {
+  const { t } = useTranslation()
+  const inviteOpen   = useTutorialStore((s) => s.inviteOpen)
+  const active       = useTutorialStore((s) => s.active)
+  const showInvite   = useTutorialStore((s) => s.showInvite)
+  const dismissInvite = useTutorialStore((s) => s.dismissInvite)
+  const start        = useTutorialStore((s) => s.start)
+
+  useEffect(() => {
+    const id = setTimeout(() => showInvite(), 2500)
+    return () => clearTimeout(id)
+  }, [showInvite])
+
+  useEffect(() => {
+    ;(window as unknown as { tuliaTour?: () => void }).tuliaTour = () => {
+      useTutorialStore.getState().reset()
+    }
+  }, [])
+
+  if (!inviteOpen || active) return null
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 w-72 rounded-lg border border-border-subtle bg-bg-secondary p-3 shadow-2xl">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="flex h-6 w-6 items-center justify-center rounded-md bg-accent/15 text-accent">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5">
+              <path d="M8 2v12M2 8h12" strokeLinecap="round" />
+            </svg>
+          </span>
+          <p className="text-sm font-medium text-text-primary">{t('tutorial.invite.title')}</p>
+        </div>
+        <button
+          onClick={dismissInvite}
+          className="text-text-muted hover:text-text-secondary transition-colors"
+          aria-label={t('common.close')}
+        >
+          <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" className="h-3 w-3">
+            <path d="M3 3l6 6M9 3l-6 6" />
+          </svg>
+        </button>
+      </div>
+      <p className="mt-1.5 text-xs text-text-secondary leading-relaxed">
+        {t('tutorial.invite.body')}
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-1.5">
+        <button
+          onClick={dismissInvite}
+          className="rounded px-2.5 py-1 text-xs text-text-muted hover:text-text-secondary hover:bg-bg-tertiary transition-colors"
+        >
+          {t('tutorial.invite.skip')}
+        </button>
+        <button
+          onClick={start}
+          className="rounded bg-accent px-2.5 py-1 text-xs font-medium text-bg-primary hover:opacity-90 transition-opacity"
+        >
+          {t('tutorial.invite.start')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tutorial/TutorialOverlay.tsx
+++ b/src/components/tutorial/TutorialOverlay.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useLayoutEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useTutorialStore } from '@/lib/store/useTutorialStore'
+import { modKey } from '@/lib/platform'
+
+type Rect = { top: number; left: number; width: number; height: number }
+
+const PAD = 10
+const TOOLTIP_W = 320
+const TOOLTIP_GAP = 16
+
+function getRect(selector: string | null): { rect: Rect | null; el: HTMLElement | null; found: boolean } {
+  if (!selector) return { rect: null, el: null, found: true }
+  // Some anchors (e.g. the Sidebar) are rendered twice — once in the mobile
+  // drawer and once in the desktop layout — with one of them hidden via
+  // display:none. Pick the first match that actually has a visible box.
+  const all = Array.from(document.querySelectorAll(selector)) as HTMLElement[]
+  if (all.length === 0) return { rect: null, el: null, found: false }
+  for (const candidate of all) {
+    const r = candidate.getBoundingClientRect()
+    if (r.width > 0 && r.height > 0) {
+      return { rect: { top: r.top, left: r.left, width: r.width, height: r.height }, el: candidate, found: true }
+    }
+  }
+  // Found in DOM but none visible yet — return the first so retry logic kicks in
+  return { rect: null, el: all[0] ?? null, found: true }
+}
+
+export function TutorialOverlay() {
+  const { t } = useTranslation()
+  const active = useTutorialStore((s) => s.active)
+  const step   = useTutorialStore((s) => s.step)
+  const steps  = useTutorialStore((s) => s.steps)
+  const next   = useTutorialStore((s) => s.next)
+  const prev   = useTutorialStore((s) => s.prev)
+  const skip   = useTutorialStore((s) => s.skip)
+
+  const current = steps[step]
+  const [rect, setRect] = useState<Rect | null>(null)
+  const [vw, setVw]     = useState(typeof window !== 'undefined' ? window.innerWidth : 1024)
+  const [vh, setVh]     = useState(typeof window !== 'undefined' ? window.innerHeight : 768)
+
+  useLayoutEffect(() => {
+    if (!active || !current) return
+
+    let cancelled = false
+    let attempts = 0
+    const timeouts: number[] = []
+
+    const update = () => {
+      if (cancelled) return
+      const { rect: r, el, found } = getRect(current.target)
+      setVw(window.innerWidth)
+      setVh(window.innerHeight)
+
+      if (!found) {
+        if (current.target) {
+          // eslint-disable-next-line no-console
+          console.warn('[Tulia tour] target not found:', current.target)
+        }
+        setRect(null)
+        return
+      }
+
+      if (!r && attempts < 12) {
+        // Element exists but has no size yet — wait & retry (e.g. animating in)
+        attempts++
+        timeouts.push(window.setTimeout(update, 80))
+        return
+      }
+
+      if (r && el) {
+        // Make sure the target is visible
+        const offscreen =
+          r.top < 0 || r.left < 0 || r.top > window.innerHeight || r.left > window.innerWidth
+        if (offscreen) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+          timeouts.push(window.setTimeout(update, 250))
+          return
+        }
+      }
+
+      setRect(r)
+    }
+
+    // Reset to null first so we don't show the previous step's spotlight while
+    // re-measuring the new one
+    setRect(null)
+    update()
+    timeouts.push(window.setTimeout(update, 60))
+
+    const onWin = () => update()
+    window.addEventListener('resize', onWin)
+    window.addEventListener('scroll', onWin, true)
+    return () => {
+      cancelled = true
+      timeouts.forEach((id) => window.clearTimeout(id))
+      window.removeEventListener('resize', onWin)
+      window.removeEventListener('scroll', onWin, true)
+    }
+  }, [active, current, step])
+
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); skip() }
+      else if (e.key === 'Enter' || e.key === 'ArrowRight') { e.preventDefault(); next() }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); prev() }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, next, prev, skip])
+
+  if (!active || !current) return null
+
+  const placement = current.placement ?? 'bottom'
+  const isCentered = !rect || placement === 'center'
+
+  let tipTop = vh / 2 - 80
+  let tipLeft = vw / 2 - TOOLTIP_W / 2
+
+  if (rect && !isCentered) {
+    if (placement === 'right') {
+      tipLeft = rect.left + rect.width + TOOLTIP_GAP
+      tipTop  = rect.top + rect.height / 2 - 60
+    } else if (placement === 'left') {
+      tipLeft = rect.left - TOOLTIP_W - TOOLTIP_GAP
+      tipTop  = rect.top + rect.height / 2 - 60
+    } else if (placement === 'top') {
+      tipLeft = rect.left + rect.width / 2 - TOOLTIP_W / 2
+      tipTop  = rect.top - 140 - TOOLTIP_GAP
+    } else {
+      tipLeft = rect.left + rect.width / 2 - TOOLTIP_W / 2
+      tipTop  = rect.top + rect.height + TOOLTIP_GAP
+    }
+    tipLeft = Math.max(12, Math.min(tipLeft, vw - TOOLTIP_W - 12))
+    tipTop  = Math.max(12, Math.min(tipTop, vh - 180))
+  }
+
+  const isFirst = step === 0
+  const isLast  = step === steps.length - 1
+
+  // Spotlight position (animates smoothly between steps via CSS transitions)
+  const spotTop    = rect ? rect.top - PAD : vh / 2
+  const spotLeft   = rect ? rect.left - PAD : vw / 2
+  const spotWidth  = rect ? rect.width + PAD * 2 : 0
+  const spotHeight = rect ? rect.height + PAD * 2 : 0
+
+  return (
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <style>{`
+        @keyframes tulia-tour-pulse {
+          0%, 100% { box-shadow: 0 0 0 0 rgba(200,169,106,0.55), 0 0 40px 8px rgba(200,169,106,0.25); }
+          50%      { box-shadow: 0 0 0 8px rgba(200,169,106,0), 0 0 60px 16px rgba(200,169,106,0.35); }
+        }
+        @keyframes tulia-tour-glow {
+          0%, 100% { opacity: 0.55; }
+          50%      { opacity: 1; }
+        }
+        @keyframes tulia-tour-fade-in {
+          from { opacity: 0; transform: translateY(4px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+
+      {/* Full-screen dim — only shows when no target (centered steps).
+          Pointer-events-none ensures clicks outside don't dismiss. */}
+      {isCentered && (
+        <div className="absolute inset-0 bg-black/65" />
+      )}
+
+      {/* Spotlight: a transparent box that "punches" a hole in the dim
+          using a huge box-shadow. CSS transitions animate between steps. */}
+      {!isCentered && rect && (
+        <>
+          <div
+            aria-hidden="true"
+            className="absolute rounded-xl"
+            style={{
+              top: spotTop,
+              left: spotLeft,
+              width: spotWidth,
+              height: spotHeight,
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.72)',
+              transition: 'top 350ms cubic-bezier(0.4, 0, 0.2, 1), left 350ms cubic-bezier(0.4, 0, 0.2, 1), width 350ms cubic-bezier(0.4, 0, 0.2, 1), height 350ms cubic-bezier(0.4, 0, 0.2, 1)',
+            }}
+          />
+          {/* Pulsing accent ring */}
+          <div
+            aria-hidden="true"
+            className="absolute rounded-xl border border-accent/80"
+            style={{
+              top: spotTop,
+              left: spotLeft,
+              width: spotWidth,
+              height: spotHeight,
+              animation: 'tulia-tour-pulse 2.2s ease-in-out infinite',
+              transition: 'top 350ms cubic-bezier(0.4, 0, 0.2, 1), left 350ms cubic-bezier(0.4, 0, 0.2, 1), width 350ms cubic-bezier(0.4, 0, 0.2, 1), height 350ms cubic-bezier(0.4, 0, 0.2, 1)',
+            }}
+          />
+          {/* Soft inner glow tint over the highlighted area */}
+          <div
+            aria-hidden="true"
+            className="absolute rounded-xl"
+            style={{
+              top: spotTop,
+              left: spotLeft,
+              width: spotWidth,
+              height: spotHeight,
+              background: 'radial-gradient(ellipse at center, rgba(200,169,106,0.10) 0%, rgba(200,169,106,0) 70%)',
+              animation: 'tulia-tour-glow 2.6s ease-in-out infinite',
+              transition: 'top 350ms cubic-bezier(0.4, 0, 0.2, 1), left 350ms cubic-bezier(0.4, 0, 0.2, 1), width 350ms cubic-bezier(0.4, 0, 0.2, 1), height 350ms cubic-bezier(0.4, 0, 0.2, 1)',
+            }}
+          />
+        </>
+      )}
+
+      {/* Tooltip card */}
+      <div
+        key={step}
+        className="pointer-events-auto absolute rounded-lg border border-border-subtle bg-bg-secondary p-4 shadow-2xl"
+        style={{
+          width: TOOLTIP_W,
+          top: tipTop,
+          left: tipLeft,
+          animation: 'tulia-tour-fade-in 220ms ease-out',
+        }}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-2xs uppercase tracking-wider text-text-muted">
+            {t('tutorial.stepCount', { current: step + 1, total: steps.length })}
+          </p>
+          <button
+            onClick={skip}
+            className="text-text-muted hover:text-text-secondary text-xs transition-colors"
+          >
+            {t('tutorial.skip')}
+          </button>
+        </div>
+        <h3 className="mt-2 text-sm font-medium text-text-primary">
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          {(t as any)(current.titleKey)}
+        </h3>
+        <p className="mt-1.5 text-xs text-text-secondary leading-relaxed">
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          {(t as any)(current.bodyKey, { modKey })}
+        </p>
+
+        {/* Progress dots */}
+        <div className="mt-3 flex items-center gap-1">
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1 flex-1 rounded-full transition-colors ${
+                i === step ? 'bg-accent' : i < step ? 'bg-accent/40' : 'bg-text-muted/25'
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-3 flex items-center justify-between">
+          <button
+            onClick={prev}
+            disabled={isFirst}
+            className="rounded px-2.5 py-1 text-xs text-text-muted hover:text-text-secondary hover:bg-bg-tertiary transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+          >
+            {t('tutorial.back')}
+          </button>
+          <button
+            onClick={next}
+            className="rounded bg-accent px-3 py-1 text-xs font-medium text-bg-primary hover:opacity-90 transition-opacity"
+          >
+            {isLast ? t('tutorial.done') : t('tutorial.next')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/store/useTutorialStore.ts
+++ b/src/lib/store/useTutorialStore.ts
@@ -1,0 +1,93 @@
+import { create } from 'zustand'
+
+const COMPLETED_KEY = 'tutorial_completed_v1'
+const DISMISSED_KEY = 'tutorial_invite_dismissed_v1'
+
+export type TutorialStep = {
+  target: string | null
+  titleKey: string
+  bodyKey: string
+  placement?: 'top' | 'bottom' | 'left' | 'right' | 'center'
+}
+
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  { target: null,                 titleKey: 'tutorial.welcome.title',   bodyKey: 'tutorial.welcome.body',   placement: 'center' },
+  { target: '[data-tour="logo"]', titleKey: 'tutorial.logo.title',      bodyKey: 'tutorial.logo.body',      placement: 'right' },
+  { target: '[data-tour="search"]',     titleKey: 'tutorial.search.title',     bodyKey: 'tutorial.search.body',     placement: 'right' },
+  { target: '[data-tour="library"]',    titleKey: 'tutorial.library.title',    bodyKey: 'tutorial.library.body',    placement: 'right' },
+  { target: '[data-tour="favorites"]',  titleKey: 'tutorial.favorites.title',  bodyKey: 'tutorial.favorites.body',  placement: 'right' },
+  { target: '[data-tour="my-notes"]',   titleKey: 'tutorial.notes.title',      bodyKey: 'tutorial.notes.body',      placement: 'right' },
+  { target: '[data-tour="my-studies"]', titleKey: 'tutorial.studies.title',    bodyKey: 'tutorial.studies.body',    placement: 'right' },
+  { target: '[data-tour="new-study"]',  titleKey: 'tutorial.newStudy.title',   bodyKey: 'tutorial.newStudy.body',   placement: 'right' },
+  { target: '[data-tour="friends"]',    titleKey: 'tutorial.friends.title',    bodyKey: 'tutorial.friends.body',    placement: 'right' },
+  { target: '[data-tour="chat"]',       titleKey: 'tutorial.chat.title',       bodyKey: 'tutorial.chat.body',       placement: 'right' },
+  { target: '[data-tour="profile"]',    titleKey: 'tutorial.profile.title',    bodyKey: 'tutorial.profile.body',    placement: 'right' },
+  { target: '[data-tour="reading"]',    titleKey: 'tutorial.reading.title',    bodyKey: 'tutorial.reading.body',    placement: 'left' },
+  { target: '[data-tour="toolbar"]',    titleKey: 'tutorial.toolbar.title',    bodyKey: 'tutorial.toolbar.body',    placement: 'bottom' },
+  { target: null,                       titleKey: 'tutorial.shortcuts.title',  bodyKey: 'tutorial.shortcuts.body',  placement: 'center' },
+  { target: null,                       titleKey: 'tutorial.done.title',       bodyKey: 'tutorial.done.body',       placement: 'center' },
+]
+
+type TutorialStore = {
+  inviteOpen: boolean
+  active: boolean
+  step: number
+  steps: TutorialStep[]
+  showInvite: () => void
+  dismissInvite: () => void
+  start: () => void
+  next: () => void
+  prev: () => void
+  skip: () => void
+  finish: () => void
+  reset: () => void
+}
+
+export const useTutorialStore = create<TutorialStore>((set, get) => ({
+  inviteOpen: false,
+  active: false,
+  step: 0,
+  steps: TUTORIAL_STEPS,
+
+  showInvite: () => {
+    if (localStorage.getItem(COMPLETED_KEY) === 'true') return
+    if (localStorage.getItem(DISMISSED_KEY) === 'true') return
+    set({ inviteOpen: true })
+  },
+
+  dismissInvite: () => {
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    set({ inviteOpen: false })
+  },
+
+  start: () => set({ inviteOpen: false, active: true, step: 0 }),
+
+  next: () => {
+    const { step, steps } = get()
+    if (step >= steps.length - 1) {
+      get().finish()
+    } else {
+      set({ step: step + 1 })
+    }
+  },
+
+  prev: () => set((s) => ({ step: Math.max(0, s.step - 1) })),
+
+  skip: () => {
+    localStorage.setItem(COMPLETED_KEY, 'true')
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    set({ active: false, inviteOpen: false, step: 0 })
+  },
+
+  finish: () => {
+    localStorage.setItem(COMPLETED_KEY, 'true')
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    set({ active: false, inviteOpen: false, step: 0 })
+  },
+
+  reset: () => {
+    localStorage.removeItem(COMPLETED_KEY)
+    localStorage.removeItem(DISMISSED_KEY)
+    set({ active: true, inviteOpen: false, step: 0 })
+  },
+}))


### PR DESCRIPTION
## Summary

Adds a dismissible guided tour that appears in the bottom-right corner on a user's first visit. Walks through Tulia's main features (sidebar, reading view, toolbar, keyboard shortcuts) with an animated dorado spotlight and a step-by-step tooltip. Spanish-first copy, also localized to English.

- New: \`useTutorialStore\` (Zustand, localStorage-persisted), \`TutorialInvite\` (bottom-right notification), \`TutorialOverlay\` (animated spotlight + tooltip card)
- Anchored via \`data-tour\` attributes on Logo, Search, Library, Favorites, My Notes, My Studies, New Study, Friends, Chat, Profile, reading area, and toolbar
- Selector resolution picks the first **visible** match per anchor — the Sidebar is mounted twice (mobile drawer + desktop), so the hidden copy would otherwise win and collapse the spotlight to a 0×0 fallback
- Keyboard nav: ←/→/Enter/Esc. Clicking the dim doesn't dismiss the tour (avoids accidental kills)
- 15 steps covering: welcome → logo → search → library → favorites → notes → studies → new study → friends → chat → profile → reading → toolbar → shortcuts → done
- Re-trigger from devtools with \`window.tuliaTour()\`

The branch also picks up the post-merge \`feat/study-chat\` commits that hadn't shipped yet (chat icon refresh, Messenger-style widget polish, study/chat membership sync hints) — those landed on the branch between the previous PR and this one.

## Test plan

- [ ] Clear localStorage (\`tutorial_completed_v1\`, \`tutorial_invite_dismissed_v1\`); reload — invite appears bottom-right after ~2.5s
- [ ] Click "Empezar"; spotlight pulses around each anchored feature, smooth transition between steps
- [ ] ←/→/Enter advance and rewind; Esc and Skip dismiss; clicking the dim does NOT dismiss
- [ ] Dismiss invite ("Ahora no"); reload — invite does not return
- [ ] Run \`window.tuliaTour()\` in devtools; tour starts again
- [ ] Switch app to English (Settings → Language); copy is translated
- [ ] Resize narrow / mobile width — sidebar steps still find the visible Sidebar instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)