### PR TITLE
Auto-jump to Meaning tab when verse has no cross-references

### DIFF
--- a/src/components/study/nodes/CrossReferencePopover.tsx
+++ b/src/components/study/nodes/CrossReferencePopover.tsx
@@ -57,6 +57,7 @@ export function CrossReferencePopover({
 }: CrossReferencePopoverProps) {
   const { t } = useTranslation();
   const [tab, setTab] = useState<Tab>('cross');
+  const [userPickedTab, setUserPickedTab] = useState(false);
   const [pos, setPos] = useState<Position | null>(null);
   const [insertedIds, setInsertedIds] = useState<Set<number>>(new Set());
   const containerRef = useRef<HTMLDivElement>(null);
@@ -66,6 +67,11 @@ export function CrossReferencePopover({
 
   const [meaning, setMeaning] = useState<ResultRow[] | null>(null);
   const [meaningError, setMeaningError] = useState(false);
+
+  const pickTab = (next: Tab) => {
+    setTab(next);
+    setUserPickedTab(true);
+  };
 
   // Fetch cross-refs in the source verse's version so the user gets results
   // in their reading language (TSK mappings live on canonical/ASV; backend
@@ -82,6 +88,17 @@ export function CrossReferencePopover({
       cancelled = true;
     };
   }, [verseId, versionId]);
+
+  // If cross-refs come back empty and the user hasn't manually picked a tab,
+  // jump to the meaning tab — many verses lack TSK mappings, and the semantic
+  // neighbours are usually a more useful default than an empty list.
+  useEffect(() => {
+    if (userPickedTab) return;
+    if (xrefs === null) return;
+    if (xrefs.length === 0 && tab === 'cross') {
+      setTab('meaning');
+    }
+  }, [xrefs, userPickedTab, tab]);
 
   // Fetch semantic neighbours lazily on first visit to the meaning tab.
   useEffect(() => {
@@ -199,10 +216,21 @@ export function CrossReferencePopover({
       </div>
 
       <div className="flex border-b border-border shrink-0">
-        <TabButton active={tab === 'cross'} onClick={() => setTab('cross')}>
-          {t('study.crossRefs.tabs.crossRefs')}
+        <TabButton
+          active={tab === 'cross'}
+          dim={xrefs !== null && xrefs.length === 0}
+          onClick={() => pickTab('cross')}
+        >
+          <span className="inline-flex items-center gap-1.5">
+            {t('study.crossRefs.tabs.crossRefs')}
+            {xrefs !== null && (
+              <span className="text-2xs text-text-muted tabular-nums">
+                {xrefs.length}
+              </span>
+            )}
+          </span>
         </TabButton>
-        <TabButton active={tab === 'meaning'} onClick={() => setTab('meaning')}>
+        <TabButton active={tab === 'meaning'} onClick={() => pickTab('meaning')}>
           <span className="inline-flex items-center gap-1">
             <Sparkles className="w-3 h-3" />
             {t('study.crossRefs.tabs.meaning')}
@@ -253,10 +281,12 @@ export function CrossReferencePopover({
 
 function TabButton({
   active,
+  dim,
   onClick,
   children,
 }: {
   active: boolean;
+  dim?: boolean;
   onClick: () => void;
   children: React.ReactNode;
 }) {
@@ -267,6 +297,7 @@ function TabButton({
       className={cn(
         'cursor-pointer flex-1 px-2 py-2 text-xs font-medium transition-colors',
         'border-b-2',
+        dim && !active && 'opacity-50',
         active
           ? 'text-text-primary border-accent'
           : 'text-text-muted border-transparent hover:text-text-primary',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -221,7 +221,7 @@
   "study.verseNode.loading": "Loading...",
   "study.verseNode.crossRefs": "Cross references",
   "study.crossRefs.title": "References for {{ref}}",
-  "study.crossRefs.empty": "No cross references for this verse.",
+  "study.crossRefs.empty": "No cross references. Try the Meaning tab for related verses.",
   "study.crossRefs.loading": "Looking up references...",
   "study.crossRefs.error": "Couldn't load references.",
   "study.crossRefs.insert": "Insert",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -221,7 +221,7 @@
   "study.verseNode.loading": "Cargando...",
   "study.verseNode.crossRefs": "Referencias cruzadas",
   "study.crossRefs.title": "Referencias para {{ref}}",
-  "study.crossRefs.empty": "No hay referencias cruzadas para este versículo.",
+  "study.crossRefs.empty": "Sin referencias cruzadas. Prueba la pestaña Significado para encontrar versículos relacionados.",
   "study.crossRefs.loading": "Buscando referencias...",
   "study.crossRefs.error": "No se pudieron cargar las referencias.",
   "study.crossRefs.insert": "Insertar",


### PR DESCRIPTION
Many verses lack TSK mappings, and landing on an empty cross-refs list is a dead end. When xrefs come back empty and the user hasn't manually selected a tab, switch to Meaning so the semantic neighbours show up directly.

Also surface a count next to the Cross tab and dim it when zero, and update the empty-state copy to point users at the Meaning tab in case they want to see what cross-refs we have anyway (none).