### PR TITLE
Disable native text selection on mobile (fixes #41)

### DIFF
--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -661,7 +661,7 @@ export function VerseList() {
 
             {/* ── Flow mode ── */}
             {readingMode === 'flow' && (
-              <p className={cn('font-reading leading-[2.2] md:leading-[2.6] tracking-wide text-text-primary select-text', textSizeClass)}>
+              <p className={cn('font-reading leading-[2.2] md:leading-[2.6] tracking-wide text-text-primary select-none md:select-text', textSizeClass)}>
                 {verses.map((verse, i) => {
                   const isSelected      = selectedVerseIds.includes(verse.id)
                   const verseHighlights = highlights[verse.apiId] ?? []


### PR DESCRIPTION
## Summary
- On mobile, dragging across the verse flow triggered the OS text-selection UI, which conflicted with the app's verse-selection model and looked buggy.
- Change `select-text` → `select-none md:select-text` on the flow-mode verse paragraph so native selection only appears on md+ screens.

Closes #41

## Test plan
- [ ] On a mobile viewport, tap+drag across verses — no native selection handles appear; verse selection still works on tap.
- [ ] On desktop, text selection still works for copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)