### PR TITLE
Break long URLs in chat bubbles (fixes #49)

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -59,7 +59,7 @@ export function MessageItem({ message, isMine, compact, showReceipt, conversatio
 
         <div
           className={cn(
-            'text-sm leading-snug px-3 py-1.5 rounded-2xl break-words whitespace-pre-wrap',
+            'text-sm leading-snug px-3 py-1.5 rounded-2xl break-words [overflow-wrap:anywhere] whitespace-pre-wrap',
             isMine
               ? 'bg-accent text-bg-primary rounded-br-md'
               : 'bg-bg-secondary border border-border-subtle text-text-primary rounded-bl-md',


### PR DESCRIPTION
## Summary
- Long links pasted into the Study chat overflowed the 360px chat widget because Tailwind's \`break-words\` (overflow-wrap: break-word) won't split inside an unbreakable token.
- Added \`[overflow-wrap:anywhere]\` to the message bubble so URLs wrap.

Closes #49

## Test plan
- [ ] Send a very long URL into the Study chat — it now wraps inside the bubble.
- [ ] Normal short messages still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)