### PR TITLE
Mark Study chat read on open (fixes #51)

### DIFF
--- a/src/components/study/StudyChatWidget.tsx
+++ b/src/components/study/StudyChatWidget.tsx
@@ -24,6 +24,7 @@ export function StudyChatWidget({ conversationId }: StudyChatWidgetProps) {
 
   const conversations = useChatStore(s => s.conversations)
   const messages = useChatStore(s => s.messages[conversationId] ?? EMPTY_MESSAGES)
+  const markRead = useChatStore(s => s.markRead)
 
   const [conversation, setConversation] = useState<Conversation | null>(null)
   const [open, setOpen] = useState(false)
@@ -64,6 +65,7 @@ export function StudyChatWidget({ conversationId }: StudyChatWidgetProps) {
     if (open) {
       lastReadMessageIdRef.current = messages.length > 0 ? messages[messages.length - 1].id : null
       setUnreadFromOpen(0)
+      markRead(conversationId).catch(() => {})
       return
     }
     const lastRead = lastReadMessageIdRef.current
@@ -78,7 +80,7 @@ export function StudyChatWidget({ conversationId }: StudyChatWidgetProps) {
       if (newer.length > prev) setPingKey(k => k + 1)
       return newer.length
     })
-  }, [open, messages, userId])
+  }, [open, messages, userId, conversationId, markRead])
 
   if (!conversation) {
     // Render nothing while we resolve. The bubble will appear once we have


### PR DESCRIPTION
## Summary
- Reading messages in the Study chat widget didn't clear the unread badge — only sending one did.
- Cause: \`StudyChatWidget\` only toggled local state on open; \`conversation.unread_count\` from the server stayed stale until the conversation list reloaded. \`send\` happened to zero it locally; \`open\` did not.
- Fix: when the panel opens, call \`useChatStore.markRead(conversationId)\` (same call \`ChatPanel.select\` already makes).

Closes #51

## Test plan
- [ ] In Study mode, receive a message from a peer — badge appears.
- [ ] Open the chat widget — badge clears immediately.
- [ ] Close the widget without sending — badge stays cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)