### PR TITLE
Add delete button to study edges (fixes #50)

### DIFF
--- a/src/components/study/edges/ArrowEdge.tsx
+++ b/src/components/study/edges/ArrowEdge.tsx
@@ -2,8 +2,8 @@ import {
   BaseEdge,
   EdgeLabelRenderer,
   getBezierPath,
+  useReactFlow,
   type EdgeProps,
-  type Edge,
 } from '@xyflow/react';
 
 export function ArrowEdge({
@@ -17,7 +17,9 @@ export function ArrowEdge({
   markerEnd,
   style = {},
   data,
+  selected,
 }: EdgeProps) {
+  const { deleteElements } = useReactFlow();
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -27,6 +29,11 @@ export function ArrowEdge({
     targetPosition,
   });
 
+  const removeEdge = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    deleteElements({ edges: [{ id }] });
+  };
+
   return (
     <>
       <BaseEdge
@@ -35,19 +42,37 @@ export function ArrowEdge({
         markerEnd={markerEnd}
         style={{ stroke: 'var(--color-text-muted)', strokeWidth: 1.5, ...style }}
       />
-      {data?.label && (
-        <EdgeLabelRenderer>
-          <div
-            className="nodrag nopan absolute text-2xs bg-surface border border-border rounded px-1.5 py-0.5 text-text-muted"
-            style={{
-              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              pointerEvents: 'all',
-            }}
-          >
-            {String(data.label)}
-          </div>
-        </EdgeLabelRenderer>
-      )}
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan absolute flex items-center gap-1.5"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: 'all',
+          }}
+        >
+          {data?.label != null && (
+            <div className="text-2xs bg-surface border border-border rounded px-1.5 py-0.5 text-text-muted">
+              {String(data.label)}
+            </div>
+          )}
+          {selected && (
+            <button
+              type="button"
+              onClick={removeEdge}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') removeEdge(e);
+              }}
+              className="flex items-center justify-center w-5 h-5 rounded-full bg-surface border border-border text-text-muted hover:text-text-primary hover:border-border-strong shadow-sm"
+              aria-label="Remove edge"
+              title="Remove edge"
+            >
+              <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                <path d="M3 3l6 6M9 3l-6 6" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </EdgeLabelRenderer>
     </>
   );
 }

--- a/src/components/study/edges/index.ts
+++ b/src/components/study/edges/index.ts
@@ -2,4 +2,5 @@ import { ArrowEdge } from './ArrowEdge';
 
 export const studyEdgeTypes = {
   arrow: ArrowEdge,
+  default: ArrowEdge,
 };


### PR DESCRIPTION
## Summary
- Edges in the Study canvas had no obvious way to be removed.
- Selecting an edge now shows a small X button at the edge label position. Clicking it calls \`deleteElements\` which routes through the existing \`onEdgesChange\` handler and the Y-doc sync.
- \`ArrowEdge\` is now registered for both \`arrow\` and \`default\` so existing edges (written with type \`default\`) pick up the new affordance without a migration.

Closes #50

## Test plan
- [ ] In Study mode, click an existing edge — X button appears at midpoint.
- [ ] Click the X — edge disappears for all collaborators.
- [ ] Pressing Backspace/Delete on a focused/selected edge still removes it (existing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)