### PR TITLE
Map similar-verse search to user's version (fixes #48)

### DIFF
--- a/src/components/study/nodes/CrossReferencePopover.tsx
+++ b/src/components/study/nodes/CrossReferencePopover.tsx
@@ -106,7 +106,7 @@ export function CrossReferencePopover({
     if (meaning !== null || meaningError) return;
     let cancelled = false;
     bibleApi
-      .semanticSimilar(verseId, 30)
+      .semanticSimilar(verseId, 30, versionId)
       .then((resp) => {
         if (cancelled) return;
         const rows: ResultRow[] = (resp?.results ?? []).map((r) => ({
@@ -123,7 +123,7 @@ export function CrossReferencePopover({
     return () => {
       cancelled = true;
     };
-  }, [tab, meaning, meaningError, verseId]);
+  }, [tab, meaning, meaningError, verseId, versionId]);
 
   // Track anchor position via rAF.
   useLayoutEffect(() => {

--- a/src/lib/bibleApi.ts
+++ b/src/lib/bibleApi.ts
@@ -118,8 +118,11 @@ export const bibleApi = {
     }
     return api.get<ApiCrossRef[]>(`/api/verses/${verseId}/cross-references?version_id=${versionId}`)
   },
-  semanticSimilar: (verseId: number, limit = 30) =>
-    api.get<ApiSemanticResponse>(`/api/verses/${verseId}/similar?limit=${limit}`),
+  semanticSimilar: (verseId: number, limit = 30, versionId?: number) => {
+    const qs = new URLSearchParams({ limit: String(limit) })
+    if (versionId != null) qs.set('version_id', String(versionId))
+    return api.get<ApiSemanticResponse>(`/api/verses/${verseId}/similar?${qs.toString()}`)
+  },
   crossRefVerseIds: (chapterId: number) => cacheFirst<number[]>(
     async () => (await db.crossRefIds.get(chapterId))?.data,
     () => api.get<number[]>(`/api/chapters/${chapterId}/cross-ref-verse-ids`),


### PR DESCRIPTION
## Summary
- The semantic-similar endpoint filtered candidate embeddings by \`bible_version_id\`, defaulting to canonical. If a non-canonical version was passed, it returned 0 results (no embeddings); if no version was passed, results were canonical text but the inserted node was tagged with the user's version, producing a label/text mismatch.
- Similarity now always scores against the canonical embeddings. When a different reading version is requested, results are remapped to that version by \`book.number\` + \`chapter.number\` + \`verse.number\`, so \`verse_id\` and \`text\` reflect the user's preferred version.
- Frontend passes the reader's \`versionId\` to \`semanticSimilar\`.

Closes #48

## Test plan
- [ ] On a non-RVR1960 reading version, open a verse node's xref popover → "Meaning" tab shows neighbours in the user's version.
- [ ] Inserting one places a verse node whose \`(VERSION)\` label matches the rendered text.
- [ ] On RVR1960, behaviour is unchanged (no remap path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)