### PR TITLE
Include app link in multi-verse share (fixes #42)

### DIFF
--- a/src/components/layout/PanelLayout.tsx
+++ b/src/components/layout/PanelLayout.tsx
@@ -88,10 +88,11 @@ export function PanelLayout({ sidebar, main, panel, leftPanel }: PanelLayoutProp
                           label: t('verse.shareVerse'),
                           onClick: () => {
                             const shareText = multiVerses.map(v => `${bookName} ${v.chapter}:${v.verse} — ${v.text}`).join('\n\n')
+                            const shareUrl = window.location.href
                             if (navigator.share) {
-                              navigator.share({ title: t('verse.shareVerse'), text: shareText })
+                              navigator.share({ title: t('verse.shareVerse'), text: shareText, url: shareUrl })
                             } else {
-                              navigator.clipboard.writeText(shareText)
+                              navigator.clipboard.writeText(`${shareText}\n\n${shareUrl}`)
                               addToast(t('toast.copied'), 'success')
                             }
                           },

--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -406,10 +406,11 @@ export function VerseList() {
             `${bookName} ${v.chapter}:${v.verse} — ${v.text}`
           ).join('\n\n')
           const refs = multiVerses.map(v => `${bookName} ${v.chapter}:${v.verse}`).join(', ')
+          const shareUrl = window.location.href
           if (navigator.share) {
-            navigator.share({ title: refs, text: shareText, url: window.location.href })
+            navigator.share({ title: refs, text: shareText, url: shareUrl })
           } else {
-            navigator.clipboard.writeText(shareText)
+            navigator.clipboard.writeText(`${shareText}\n\n${shareUrl}`)
             addToast(t('toast.copied'), 'success')
           }
         },


### PR DESCRIPTION
## Summary
- Multi-verse share on mobile (\`PanelLayout\`) didn't include a URL in \`navigator.share\` and the clipboard fallback was text-only. Single-verse share already passed \`window.location.href\` — bring multi-verse to parity.
- Desktop multi-verse clipboard fallback now also appends the URL.

Closes #42

## Test plan
- [ ] On mobile, select two+ verses → share via the floating selection toolbar → share sheet shows the app URL.
- [ ] On desktop with \`navigator.share\` unavailable, copying multi-verse share writes text + URL.
- [ ] Single-verse share unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)