### PR TITLE
Hover-favorite icon on verse rows (closes #25)

### DIFF
--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -801,6 +801,40 @@ export function VerseList() {
                       >
                         <IconMore />
                       </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          if (requireLogin()) return
+                          toggleBookmark(verse.apiId)
+                            .then(() => {
+                              if (!isBookmarked) {
+                                setBurstId(verse.apiId)
+                                setTimeout(() => setBurstId(null), 900)
+                              }
+                            })
+                            .catch((error) => {
+                              if (isAuthError(error)) {
+                                addToast(t('study.loginRequired'), 'error', {
+                                  action: { label: t('auth.logIn'), onClick: openAuthModal },
+                                })
+                                return
+                              }
+                              addToast(t('toast.bookmarkFailed'), 'error')
+                            })
+                        }}
+                        className={cn(
+                          'hidden md:inline-flex shrink-0 self-start mt-0.5 h-8 w-8 items-center justify-center rounded-md transition-opacity',
+                          'hover:bg-bg-tertiary',
+                          isBookmarked
+                            ? 'text-[var(--fav)] opacity-100'
+                            : 'text-text-muted opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--fav)]',
+                        )}
+                        aria-label={isBookmarked ? t('verse.removeFromFavorites') : t('verse.addToFavorites')}
+                        title={isBookmarked ? t('verse.removeFromFavorites') : t('verse.addToFavorites')}
+                      >
+                        <HeartIcon size={14} filled={isBookmarked} />
+                      </button>
                     </div>
                   )
                 })}


### PR DESCRIPTION
## Summary
- Adds a hover-revealed heart button on the right side of each verse row in Verse reading mode (desktop only).
- Persists as filled when the verse is bookmarked, hidden otherwise until the user hovers/focuses the row.
- Reuses the existing \`toggleBookmark\` flow with the same login gate, error toast, and burst animation as the context-menu action.

Closes #25

## Test plan
- [ ] In Verse reading mode, hover a verse row → heart button appears on the right.
- [ ] Click → bookmark toggles, burst animation plays on add, button becomes filled.
- [ ] When already bookmarked, button is visible without hover.
- [ ] Logged-out users get the login prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)