### PR TITLE
Fix invisible study-canvas edges

### DIFF
--- a/src/components/study/edges/ArrowEdge.tsx
+++ b/src/components/study/edges/ArrowEdge.tsx
@@ -40,7 +40,7 @@ export function ArrowEdge({
         id={id}
         path={edgePath}
         markerEnd={markerEnd}
-        style={{ stroke: 'var(--color-text-muted)', strokeWidth: 1.5, ...style }}
+        style={{ stroke: 'var(--text-muted)', strokeWidth: 1.5, ...style }}
       />
       <EdgeLabelRenderer>
         <div


### PR DESCRIPTION
## Summary
- After #57 made \`ArrowEdge\` the default edge type, all edges disappeared.
- Cause: \`stroke: var(--color-text-muted)\` — that CSS variable isn't defined; the project's variable is \`--text-muted\`. The bug existed in \`ArrowEdge\` from before but was inert while no edges actually used the \`arrow\` type.
- Fix: use \`var(--text-muted)\`.

## Test plan
- [ ] Open a study session with existing edges → strokes are visible.
- [ ] Connect two nodes → new edge renders.
- [ ] Select edge → X button appears, click removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)