### PR TITLE
Drawing tool + updater endpoint move

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI3NzJEQ0JCRkYzRUEyMjgKUldRb29qNy91OXh5SjMrRmtDaElxWE9zM3Nyc21ISlZBSVYycTBaazZ6M1EzekNidUZ5ZmphdWUK",
       "endpoints": [
-        "https://github.com/freddysae0/tulia-bible/releases/latest/download/latest.json"
+        "https://github.com/Tulia-Study/tulia-bible/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/src/components/study/DrawingLayer.tsx
+++ b/src/components/study/DrawingLayer.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+import type { StrokeKind } from '@/lib/study/strokes';
+
+export interface DrawSettings {
+  kind: StrokeKind;
+  color: string;
+  size: number;
+  filled: boolean;
+}
+
+interface DrawingLayerProps {
+  active: boolean;
+  erasing: boolean;
+  paused?: boolean;
+  settings: DrawSettings;
+  /** Begin a new stroke at flow point. Returns the new node id. */
+  beginStroke: (settings: DrawSettings, point: { x: number; y: number }) => string | null;
+  /** Append a point to an in-progress stroke (pen) or update endpoint (shape). */
+  extendStroke: (id: string, kind: StrokeKind, point: { x: number; y: number }) => void;
+  /** Finalize a stroke: lock viewBox, commit undo step. */
+  finishStroke: (id: string) => void;
+  /** Erase strokes whose geometry intersects the given flow point. */
+  eraseAtFlow: (point: { x: number; y: number }) => void;
+}
+
+const POINT_INTERVAL_MS = 16;
+
+export function DrawingLayer({
+  active,
+  erasing,
+  paused = false,
+  settings,
+  beginStroke,
+  extendStroke,
+  finishStroke,
+  eraseAtFlow,
+}: DrawingLayerProps) {
+  const { screenToFlowPosition } = useReactFlow();
+
+  const isDrawingRef = useRef(false);
+  const activeIdRef = useRef<string | null>(null);
+  const activeKindRef = useRef<StrokeKind | null>(null);
+  const pendingPointRef = useRef<{ x: number; y: number } | null>(null);
+  const lastWriteAtRef = useRef(0);
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Latest props for stable window listeners.
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const erasingRef = useRef(erasing);
+  erasingRef.current = erasing;
+  const beginRef = useRef(beginStroke);
+  beginRef.current = beginStroke;
+  const extendRef = useRef(extendStroke);
+  extendRef.current = extendStroke;
+  const finishRef = useRef(finishStroke);
+  finishRef.current = finishStroke;
+  const eraseRef = useRef(eraseAtFlow);
+  eraseRef.current = eraseAtFlow;
+
+  const flowPoint = useCallback(
+    (clientX: number, clientY: number) => screenToFlowPosition({ x: clientX, y: clientY }),
+    [screenToFlowPosition],
+  );
+
+  const flushPending = useCallback(() => {
+    const p = pendingPointRef.current;
+    const id = activeIdRef.current;
+    const kind = activeKindRef.current;
+    if (!p || !id || !kind) return;
+    extendRef.current(id, kind, p);
+    pendingPointRef.current = null;
+    lastWriteAtRef.current = performance.now();
+  }, []);
+
+  const schedule = useCallback(() => {
+    if (writeTimerRef.current) return;
+    const elapsed = performance.now() - lastWriteAtRef.current;
+    const wait = Math.max(0, POINT_INTERVAL_MS - elapsed);
+    writeTimerRef.current = setTimeout(() => {
+      writeTimerRef.current = null;
+      flushPending();
+    }, wait);
+  }, [flushPending]);
+
+  useEffect(() => {
+    if (!active || paused) return;
+
+    const isDrawableTarget = (e: PointerEvent) => {
+      const path = e.composedPath();
+      let onPane = false;
+      for (const el of path) {
+        if (!(el instanceof HTMLElement)) continue;
+        const cl = el.classList;
+        // Allow drawing on top of existing drawing nodes; non-drawing nodes block.
+        if (cl.contains('react-flow__node') && !cl.contains('react-flow__node-drawing')) {
+          return false;
+        }
+        if (
+          cl.contains('react-flow__edge') ||
+          cl.contains('react-flow__controls') ||
+          cl.contains('react-flow__minimap') ||
+          cl.contains('react-flow__panel') ||
+          cl.contains('react-flow__resize-control')
+        ) {
+          return false;
+        }
+        if (
+          cl.contains('react-flow__pane') ||
+          cl.contains('react-flow__viewport') ||
+          cl.contains('react-flow') ||
+          cl.contains('react-flow__node-drawing')
+        ) {
+          onPane = true;
+        }
+      }
+      return onPane;
+    };
+
+    const onDown = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      if (!isDrawableTarget(e)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      isDrawingRef.current = true;
+      const p = flowPoint(e.clientX, e.clientY);
+
+      if (erasingRef.current) {
+        eraseRef.current(p);
+        return;
+      }
+
+      const s = settingsRef.current;
+      const id = beginRef.current(s, p);
+      if (!id) return;
+      activeIdRef.current = id;
+      activeKindRef.current = s.kind;
+      lastWriteAtRef.current = performance.now();
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!isDrawingRef.current) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const p = flowPoint(e.clientX, e.clientY);
+      if (erasingRef.current) {
+        eraseRef.current(p);
+        return;
+      }
+      if (!activeIdRef.current) return;
+      pendingPointRef.current = p;
+      schedule();
+    };
+
+    const onUp = (e: PointerEvent) => {
+      if (!isDrawingRef.current) return;
+      isDrawingRef.current = false;
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (writeTimerRef.current) {
+        clearTimeout(writeTimerRef.current);
+        writeTimerRef.current = null;
+      }
+      if (pendingPointRef.current) flushPending();
+
+      const id = activeIdRef.current;
+      activeIdRef.current = null;
+      activeKindRef.current = null;
+      if (id) finishRef.current(id);
+    };
+
+    window.addEventListener('pointerdown', onDown, { capture: true });
+    window.addEventListener('pointermove', onMove, { capture: true });
+    window.addEventListener('pointerup', onUp, { capture: true });
+    window.addEventListener('pointercancel', onUp, { capture: true });
+
+    return () => {
+      window.removeEventListener('pointerdown', onDown, { capture: true } as any);
+      window.removeEventListener('pointermove', onMove, { capture: true } as any);
+      window.removeEventListener('pointerup', onUp, { capture: true } as any);
+      window.removeEventListener('pointercancel', onUp, { capture: true } as any);
+    };
+  }, [active, paused, flowPoint, flushPending, schedule]);
+
+  useEffect(() => {
+    return () => {
+      if (writeTimerRef.current) clearTimeout(writeTimerRef.current);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/study/StudyCanvas.tsx
+++ b/src/components/study/StudyCanvas.tsx
@@ -34,10 +34,12 @@ import {
   writeNodeToMap,
   writeEdgeToMap,
 } from '@/lib/study/yDocHelpers';
+import { pointsBounds, strokeHit, type StrokeData, type StrokeKind } from '@/lib/study/strokes';
 import { StudyDocContext } from '@/lib/study/StudyDocContext';
 import { studyNodeTypes } from './nodes';
 import { studyEdgeTypes } from './edges';
 import { RemoteCursors } from './cursor/RemoteCursors';
+import { DrawingLayer, type DrawSettings } from './DrawingLayer';
 import type { Tool } from './StudyMode';
 import type { AwarenessUser } from '@/hooks/useStudySession';
 
@@ -56,6 +58,8 @@ interface StudyCanvasProps {
   setLocalSelection: (nodeIds: string[]) => void;
   setLocalDragging: (dragging: boolean) => void;
   isGuest: boolean;
+  drawSettings: DrawSettings;
+  spaceHeld: boolean;
 }
 
 function stripEphemeralNodeData(data: any) {
@@ -153,6 +157,8 @@ function StudyCanvasInner({
   setLocalSelection,
   setLocalDragging,
   isGuest,
+  drawSettings,
+  spaceHeld,
 }: StudyCanvasProps) {
   const activeSession = useStudyStore((s) => s.activeSession);
   const { screenToFlowPosition, zoomIn, zoomOut, fitView } = useReactFlow();
@@ -956,6 +962,119 @@ function StudyCanvasInner({
     undoManagerRef.current?.stopCapturing();
   }, [isGuest]);
 
+  // --- Drawing strokes (as 'drawing' nodes for native selection/move/resize) ---
+  const beginStroke = useCallback(
+    (s: DrawSettings, point: { x: number; y: number }): string | null => {
+      if (isGuest) return null;
+      const d = docRef.current;
+      if (!d) return null;
+      const id = `draw-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const data: StrokeData = {
+        kind: s.kind,
+        color: s.color,
+        size: s.size,
+        filled: s.filled,
+        points: [point.x, point.y],
+        viewBox: { x: point.x, y: point.y, w: 1, h: 1 },
+        authorId: user?.id,
+      };
+      const position = { x: point.x, y: point.y };
+      d.transact(() => {
+        const nodesMap = getNodesMap(d);
+        writeNodeToMap(nodesMap, { id, type: 'drawing', position, width: 1, height: 1, data });
+      }, 'local');
+      setNodes((nds) => [
+        ...nds,
+        { id, type: 'drawing', position, width: 1, height: 1, data } as unknown as Node,
+      ]);
+      return id;
+    },
+    [isGuest, user?.id],
+  );
+
+  const extendStroke = useCallback(
+    (id: string, kind: StrokeKind, point: { x: number; y: number }) => {
+      if (isGuest) return;
+      const d = docRef.current;
+      if (!d) return;
+      const current = displayedNodesRef.current.find((n) => n.id === id);
+      if (!current) return;
+      const prev = current.data as unknown as StrokeData;
+      const newPoints =
+        kind === 'pen'
+          ? [...prev.points, point.x, point.y]
+          : prev.points.length >= 2
+          ? [prev.points[0], prev.points[1], point.x, point.y]
+          : [point.x, point.y];
+      const bounds = pointsBounds(newPoints);
+      const newData: StrokeData = { ...prev, points: newPoints, viewBox: bounds };
+      const position = { x: bounds.x, y: bounds.y };
+      d.transact(() => {
+        const nodesMap = getNodesMap(d);
+        const m = nodesMap.get(id);
+        if (!m) return;
+        m.set('data', newData);
+        m.set('position', position);
+        m.set('width', bounds.w);
+        m.set('height', bounds.h);
+      }, 'local');
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === id
+            ? ({ ...n, position, width: bounds.w, height: bounds.h, data: newData } as unknown as Node)
+            : n,
+        ),
+      );
+    },
+    [isGuest],
+  );
+
+  const finishStroke = useCallback(
+    (_id: string) => {
+      undoManagerRef.current?.stopCapturing();
+    },
+    [],
+  );
+
+  const eraseAtFlow = useCallback(
+    (p: { x: number; y: number }) => {
+      if (isGuest) return;
+      const d = docRef.current;
+      if (!d) return;
+      const zoom = rfStore.getState().transform[2] || 1;
+      const flowThreshold = 4 / zoom;
+      const toDelete: string[] = [];
+      for (const n of displayedNodesRef.current) {
+        if (n.type !== 'drawing') continue;
+        const data = n.data as unknown as StrokeData;
+        if (!data?.viewBox) continue;
+        const w = (n as any).width ?? data.viewBox.w;
+        const h = (n as any).height ?? data.viewBox.h;
+        const sx = w / data.viewBox.w;
+        const sy = h / data.viewBox.h;
+        const scale = Math.min(sx, sy); // 'meet'
+        if (scale <= 0) continue;
+        const offsetX = (w - data.viewBox.w * scale) / 2;
+        const offsetY = (h - data.viewBox.h * scale) / 2;
+        const localX = p.x - n.position.x;
+        const localY = p.y - n.position.y;
+        const sxg = data.viewBox.x + (localX - offsetX) / scale;
+        const syg = data.viewBox.y + (localY - offsetY) / scale;
+        if (strokeHit(data, sxg, syg, flowThreshold / scale)) {
+          toDelete.push(n.id);
+        }
+      }
+      if (toDelete.length === 0) return;
+      d.transact(() => {
+        const nodesMap = getNodesMap(d);
+        toDelete.forEach((id) => nodesMap.delete(id));
+      }, 'local');
+      const dropped = new Set(toDelete);
+      setNodes((nds) => nds.filter((n) => !dropped.has(n.id)));
+    },
+    [isGuest, rfStore],
+  );
+
 useEffect(() => {
     (window as any).__studyCanvasActions = { addStickyNote, addVerseNode, addPassageNode, addVerseChain, addCrossRefNode, addAiNoteNode, setVerseNodeVersion, undo, redo, resizeNode, zoomIn, zoomOut, fitView, toggleLock };
     (window as any).__studyCanvasState = { isLocked: !isInteractive };
@@ -1064,10 +1183,22 @@ useEffect(() => {
           deleteKeyCode={['Backspace', 'Delete']}
           multiSelectionKeyCode="Shift"
           selectionKeyCode="Shift"
-          className="bg-bg-secondary"
+          className={`bg-bg-secondary${
+            tool === 'draw' || tool === 'erase'
+              ? spaceHeld
+                ? ' cursor-grab'
+                : tool === 'erase'
+                ? ' [&_.react-flow__pane]:cursor-cell'
+                : ' [&_.react-flow__pane]:cursor-crosshair'
+              : ''
+          }`}
           defaultEdgeOptions={{ type: 'default', animated: false }}
           proOptions={{ hideAttribution: true }}
-          panOnDrag={tool === 'hand' || isGuest ? [0, 1] : [1]}
+          panOnDrag={
+            tool === 'draw' || tool === 'erase'
+              ? (spaceHeld ? [0, 1] : [1])
+              : (tool === 'hand' || isGuest ? [0, 1] : [1])
+          }
           nodesDraggable={!isGuest && tool === 'select'}
           nodesConnectable={!isGuest && tool === 'select'}
           elementsSelectable={!isGuest || tool === 'select'}
@@ -1090,6 +1221,16 @@ useEffect(() => {
             }}
           />
           <RemoteCursors users={users} currentUserId={user?.id} />
+          <DrawingLayer
+            active={!isGuest && (tool === 'draw' || tool === 'erase')}
+            paused={spaceHeld}
+            erasing={tool === 'erase'}
+            settings={drawSettings}
+            beginStroke={beginStroke}
+            extendStroke={extendStroke}
+            finishStroke={finishStroke}
+            eraseAtFlow={eraseAtFlow}
+          />
         </ReactFlow>
       </div>
     </StudyDocContext.Provider>

--- a/src/components/study/StudyMode.tsx
+++ b/src/components/study/StudyMode.tsx
@@ -10,8 +10,12 @@ import { StudyToolbar } from './StudyToolbar'
 import { StudyCanvas } from './StudyCanvas'
 import { BiblePanel } from './BiblePanel'
 import { StudyChatWidget } from './StudyChatWidget'
+import type { DrawSettings } from './DrawingLayer'
 
-export type Tool = 'select' | 'hand' | 'sticky' | 'verse'
+export type Tool = 'select' | 'hand' | 'sticky' | 'verse' | 'draw' | 'erase'
+
+export const DRAW_COLORS = ['#e5e7eb', '#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#a855f7'] as const
+export const DRAW_SIZES = [2, 4, 8] as const
 
 export function StudyMode() {
   const navigate = useNavigate()
@@ -23,6 +27,13 @@ export function StudyMode() {
   const [tool, setTool] = useState<Tool>('select')
   const [showInsertVerse, setShowInsertVerse] = useState(false)
   const [biblePanelOpen, setBiblePanelOpen] = useState(false)
+  const [drawSettings, setDrawSettings] = useState<DrawSettings>({
+    kind: 'pen',
+    color: DRAW_COLORS[0],
+    size: DRAW_SIZES[1],
+    filled: false,
+  })
+  const [spaceHeld, setSpaceHeld] = useState(false)
 
   const sessionId = activeSession?.id ?? null
   const {
@@ -106,10 +117,65 @@ export function StudyMode() {
         setBiblePanelOpen(v => !v)
         return
       }
+      if (e.key === 'd' || e.key === 'D') { setTool('draw'); return }
+      if (e.key === 'e' || e.key === 'E') { setTool('erase'); return }
+
+      if (tool === 'draw') {
+        if (e.key === '[') {
+          setDrawSettings(s => {
+            const idx = Math.max(0, DRAW_SIZES.indexOf(s.size as typeof DRAW_SIZES[number]) - 1)
+            return { ...s, size: DRAW_SIZES[idx] }
+          })
+          return
+        }
+        if (e.key === ']') {
+          setDrawSettings(s => {
+            const i = DRAW_SIZES.indexOf(s.size as typeof DRAW_SIZES[number])
+            const idx = Math.min(DRAW_SIZES.length - 1, (i < 0 ? 0 : i) + 1)
+            return { ...s, size: DRAW_SIZES[idx] }
+          })
+          return
+        }
+        const colorIdx = ['1', '2', '3', '4', '5', '6'].indexOf(e.key)
+        if (colorIdx >= 0 && colorIdx < DRAW_COLORS.length) {
+          setDrawSettings(s => ({ ...s, color: DRAW_COLORS[colorIdx] }))
+          return
+        }
+      }
     }
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
-  }, [showInsertVerse, getActions, isGuest, openAuthModal])
+  }, [showInsertVerse, getActions, isGuest, openAuthModal, tool])
+
+  useEffect(() => {
+    if (tool !== 'draw' && tool !== 'erase') {
+      if (spaceHeld) setSpaceHeld(false)
+      return
+    }
+    const isInputTarget = (t: EventTarget | null) => {
+      const tag = (t as HTMLElement | null)?.tagName
+      return tag === 'INPUT' || tag === 'TEXTAREA' || (t as HTMLElement | null)?.isContentEditable
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'Space' || e.repeat) return
+      if (isInputTarget(e.target)) return
+      e.preventDefault()
+      setSpaceHeld(true)
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== 'Space') return
+      setSpaceHeld(false)
+    }
+    const onBlur = () => setSpaceHeld(false)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [tool, spaceHeld])
 
   return (
     <div className="fixed inset-0 z-50 bg-bg-primary flex flex-col">
@@ -141,6 +207,8 @@ export function StudyMode() {
           biblePanelOpen={biblePanelOpen}
           onToggleBiblePanel={() => setBiblePanelOpen(v => !v)}
           isGuest={isGuest}
+          drawSettings={drawSettings}
+          onDrawSettingsChange={setDrawSettings}
         />
         <StudyCanvas
           tool={tool}
@@ -154,6 +222,8 @@ export function StudyMode() {
           setLocalSelection={setLocalSelection}
           setLocalDragging={setLocalDragging}
           isGuest={isGuest}
+          drawSettings={drawSettings}
+          spaceHeld={spaceHeld}
         />
         <BiblePanel open={biblePanelOpen} onClose={() => setBiblePanelOpen(false)} />
         {!isGuest && activeSession?.conversation_id && (

--- a/src/components/study/StudyToolbar.tsx
+++ b/src/components/study/StudyToolbar.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MousePointer2, Hand, StickyNote, BookOpen, Undo, Redo, ZoomIn, ZoomOut, Maximize2, Lock, Unlock } from 'lucide-react';
+import { MousePointer2, Hand, StickyNote, BookOpen, Undo, Redo, ZoomIn, ZoomOut, Maximize2, Lock, Unlock, Pencil, Eraser, Minus, ArrowRight, Square, Circle } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { modKey } from '@/lib/platform';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { InsertVerseModal } from './InsertVerseModal';
 import { useUIStore } from '@/lib/store/useUIStore';
-import type { Tool } from './StudyMode';
+import { DRAW_COLORS, DRAW_SIZES, type Tool } from './StudyMode';
+import type { DrawSettings } from './DrawingLayer';
+import type { StrokeKind } from '@/lib/study/strokes';
 
 function ToolbarButton({
   icon, active, onClick, disabled,
@@ -36,9 +38,19 @@ interface StudyToolbarProps {
   biblePanelOpen: boolean;
   onToggleBiblePanel: () => void;
   isGuest: boolean;
+  drawSettings: DrawSettings;
+  onDrawSettingsChange: (next: DrawSettings) => void;
 }
 
-export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsertVerse, onCloseInsertVerse, biblePanelOpen, onToggleBiblePanel, isGuest }: StudyToolbarProps) {
+const STROKE_KINDS: { kind: StrokeKind; icon: React.ReactNode; label: string }[] = [
+  { kind: 'pen', icon: <Pencil className="w-3.5 h-3.5" />, label: 'Pen' },
+  { kind: 'line', icon: <Minus className="w-3.5 h-3.5" />, label: 'Line' },
+  { kind: 'arrow', icon: <ArrowRight className="w-3.5 h-3.5" />, label: 'Arrow' },
+  { kind: 'rect', icon: <Square className="w-3.5 h-3.5" />, label: 'Rectangle' },
+  { kind: 'ellipse', icon: <Circle className="w-3.5 h-3.5" />, label: 'Ellipse' },
+];
+
+export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsertVerse, onCloseInsertVerse, biblePanelOpen, onToggleBiblePanel, isGuest, drawSettings, onDrawSettingsChange }: StudyToolbarProps) {
   const { t } = useTranslation();
   const getActions = useCallback(() => (window as any).__studyCanvasActions, []);
   const openAuthModal = useUIStore(s => s.openAuthModal);
@@ -63,6 +75,18 @@ export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsert
     setLocked(v => !v);
     getActions()?.toggleLock?.();
   }, [getActions]);
+
+  const handleDraw = useCallback(() => {
+    if (isGuest) { openAuthModal('login'); return; }
+    onToolChange('draw');
+  }, [isGuest, openAuthModal, onToolChange]);
+
+  const handleErase = useCallback(() => {
+    if (isGuest) { openAuthModal('login'); return; }
+    onToolChange('erase');
+  }, [isGuest, openAuthModal, onToolChange]);
+
+  const drawPopoverOpen = tool === 'draw';
 
   return (
     <>
@@ -98,6 +122,16 @@ export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsert
               onClick={handleVerse}
               disabled={isGuest}
             />
+          </Tooltip>
+
+          <div className="h-px bg-border mx-1" />
+
+          {/* Draw */}
+          <Tooltip label={isGuest ? 'Log in to edit' : 'Draw (D)'} side="right">
+            <ToolbarButton icon={<Pencil className="w-4 h-4" />} active={tool === 'draw'} onClick={handleDraw} disabled={isGuest} />
+          </Tooltip>
+          <Tooltip label={isGuest ? 'Log in to edit' : 'Eraser (E)'} side="right">
+            <ToolbarButton icon={<Eraser className="w-4 h-4" />} active={tool === 'erase'} onClick={handleErase} disabled={isGuest} />
           </Tooltip>
 
           <div className="h-px bg-border mx-1" />
@@ -142,6 +176,90 @@ export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsert
           </Tooltip>
         </div>
       </div>
+
+      {drawPopoverOpen && (
+        <div
+          className={cn(
+            'absolute top-1/2 -translate-y-1/2 z-10 transition-all duration-300',
+            biblePanelOpen ? 'left-[492px]' : 'left-[60px]',
+          )}
+        >
+          <div className="rounded-2xl bg-surface/95 backdrop-blur shadow-lg border border-border p-2 flex flex-col gap-2 min-w-[160px]">
+            <div className="text-2xs uppercase tracking-wide text-text-muted px-1">Brush</div>
+            <div className="flex gap-1">
+              {STROKE_KINDS.map(({ kind, icon, label }) => (
+                <Tooltip key={kind} label={label} side="bottom">
+                  <button
+                    onClick={() => onDrawSettingsChange({ ...drawSettings, kind })}
+                    className={cn(
+                      'w-7 h-7 flex items-center justify-center rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors',
+                      drawSettings.kind === kind && 'text-accent bg-bg-tertiary',
+                    )}
+                  >
+                    {icon}
+                  </button>
+                </Tooltip>
+              ))}
+            </div>
+
+            <div className="text-2xs uppercase tracking-wide text-text-muted px-1 mt-1">Color</div>
+            <div className="flex gap-1.5 px-1">
+              {DRAW_COLORS.map((c, i) => (
+                <Tooltip key={c} label={`${i + 1}`} side="bottom">
+                  <button
+                    onClick={() => onDrawSettingsChange({ ...drawSettings, color: c })}
+                    className={cn(
+                      'w-5 h-5 rounded-full border transition-transform',
+                      drawSettings.color === c ? 'border-text-primary scale-110' : 'border-border',
+                    )}
+                    style={{ backgroundColor: c }}
+                    aria-label={`Color ${i + 1}`}
+                  />
+                </Tooltip>
+              ))}
+            </div>
+
+            <div className="text-2xs uppercase tracking-wide text-text-muted px-1 mt-1">Size</div>
+            <div className="flex gap-1.5 items-center px-1">
+              {DRAW_SIZES.map((sz, i) => (
+                <Tooltip key={sz} label={`${i === 0 ? 'Small' : i === 1 ? 'Medium' : 'Large'} ([ ])`} side="bottom">
+                  <button
+                    onClick={() => onDrawSettingsChange({ ...drawSettings, size: sz })}
+                    className={cn(
+                      'h-7 px-2 rounded-md flex items-center justify-center hover:bg-bg-tertiary transition-colors',
+                      drawSettings.size === sz && 'bg-bg-tertiary',
+                    )}
+                  >
+                    <span
+                      className="rounded-full"
+                      style={{
+                        width: sz * 1.6,
+                        height: sz * 1.6,
+                        backgroundColor: drawSettings.color,
+                      }}
+                    />
+                  </button>
+                </Tooltip>
+              ))}
+            </div>
+
+            {(drawSettings.kind === 'rect' || drawSettings.kind === 'ellipse') && (
+              <>
+                <div className="h-px bg-border" />
+                <label className="flex items-center gap-2 px-1 text-xs text-text-secondary cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={drawSettings.filled}
+                    onChange={(e) => onDrawSettingsChange({ ...drawSettings, filled: e.target.checked })}
+                    className="accent-accent"
+                  />
+                  Filled
+                </label>
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       <InsertVerseModal open={showInsertVerse} onClose={onCloseInsertVerse} />
     </>

--- a/src/components/study/nodes/DrawingNode.tsx
+++ b/src/components/study/nodes/DrawingNode.tsx
@@ -1,0 +1,87 @@
+import { memo } from 'react';
+import { NodeResizer, type NodeProps } from '@xyflow/react';
+import { cn } from '@/lib/cn';
+import { buildPenPath, strokeGeometryBounds, type StrokeData } from '@/lib/study/strokes';
+
+function StrokeShape({ data }: { data: StrokeData }) {
+  const { kind, color, size, points, filled } = data;
+  const common = {
+    stroke: color,
+    strokeWidth: size,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    fill: filled ? color : 'none',
+  };
+
+  if (kind === 'pen') {
+    if (points.length < 2) return null;
+    if (points.length === 2) {
+      // Single dot
+      return <circle cx={points[0]} cy={points[1]} r={size / 2} fill={color} />;
+    }
+    return <path d={buildPenPath(points)} {...common} fill="none" />;
+  }
+  if (kind === 'line') {
+    if (points.length < 4) return null;
+    return <line x1={points[0]} y1={points[1]} x2={points[2]} y2={points[3]} {...common} fill="none" />;
+  }
+  if (kind === 'arrow') {
+    if (points.length < 4) return null;
+    const [x1, y1, x2, y2] = points;
+    const ang = Math.atan2(y2 - y1, x2 - x1);
+    const head = Math.max(8, size * 3);
+    const ax = x2 - Math.cos(ang - Math.PI / 6) * head;
+    const ay = y2 - Math.sin(ang - Math.PI / 6) * head;
+    const bx = x2 - Math.cos(ang + Math.PI / 6) * head;
+    const by = y2 - Math.sin(ang + Math.PI / 6) * head;
+    return (
+      <g {...common} fill="none">
+        <line x1={x1} y1={y1} x2={x2} y2={y2} />
+        <polyline points={`${ax},${ay} ${x2},${y2} ${bx},${by}`} />
+      </g>
+    );
+  }
+  if (kind === 'rect') {
+    const b = strokeGeometryBounds(data);
+    return <rect x={b.x} y={b.y} width={b.w} height={b.h} {...common} />;
+  }
+  if (kind === 'ellipse') {
+    const b = strokeGeometryBounds(data);
+    return <ellipse cx={b.x + b.w / 2} cy={b.y + b.h / 2} rx={b.w / 2} ry={b.h / 2} {...common} />;
+  }
+  return null;
+}
+
+export const DrawingNode = memo(function DrawingNode({ data, selected }: NodeProps) {
+  const stroke = data as unknown as StrokeData;
+  const vb = stroke.viewBox ?? { x: 0, y: 0, w: 1, h: 1 };
+
+  return (
+    <div
+      className={cn(
+        'relative w-full h-full rounded-sm transition-shadow',
+        selected && 'ring-2 ring-accent',
+      )}
+    >
+      <NodeResizer
+        isVisible={!!selected}
+        keepAspectRatio
+        minWidth={20}
+        minHeight={20}
+        lineStyle={{ borderWidth: 6, borderColor: 'transparent' }}
+        lineClassName="hover:!border-accent/60 transition-colors"
+        handleStyle={{ width: 10, height: 10, borderRadius: 3 }}
+        handleClassName="!bg-accent !border-2 !border-bg-primary"
+      />
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`${vb.x} ${vb.y} ${Math.max(1, vb.w)} ${Math.max(1, vb.h)}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ overflow: 'visible', pointerEvents: 'none' }}
+      >
+        <StrokeShape data={stroke} />
+      </svg>
+    </div>
+  );
+});

--- a/src/components/study/nodes/index.ts
+++ b/src/components/study/nodes/index.ts
@@ -3,6 +3,7 @@ import { VerseNode } from './VerseNode';
 import { PassageNode } from './PassageNode';
 import { CommentNode } from './CommentNode';
 import { AiNoteNode } from './AiNoteNode';
+import { DrawingNode } from './DrawingNode';
 
 export const studyNodeTypes = {
   sticky: StickyNode,
@@ -10,4 +11,5 @@ export const studyNodeTypes = {
   passage: PassageNode,
   comment: CommentNode,
   'ai-note': AiNoteNode,
+  drawing: DrawingNode,
 };

--- a/src/lib/study/strokes.ts
+++ b/src/lib/study/strokes.ts
@@ -1,0 +1,118 @@
+export type StrokeKind = 'pen' | 'line' | 'arrow' | 'rect' | 'ellipse';
+
+export interface StrokeData {
+  kind: StrokeKind;
+  color: string;
+  size: number;
+  filled: boolean;
+  /** Flat array of absolute flow coords [x0,y0,x1,y1,...]. */
+  points: number[];
+  /** SVG viewBox in flow coords; locked at draw-finish so resize/move don't change geometry. */
+  viewBox: { x: number; y: number; w: number; h: number };
+  authorId?: string | number;
+}
+
+export function buildPenPath(points: number[]): string {
+  if (points.length < 2) return '';
+  let d = `M ${points[0]} ${points[1]}`;
+  if (points.length === 2) return d;
+  for (let i = 2; i < points.length - 2; i += 2) {
+    const x = points[i];
+    const y = points[i + 1];
+    const xn = points[i + 2];
+    const yn = points[i + 3];
+    const mx = (x + xn) / 2;
+    const my = (y + yn) / 2;
+    d += ` Q ${x} ${y} ${mx} ${my}`;
+  }
+  d += ` L ${points[points.length - 2]} ${points[points.length - 1]}`;
+  return d;
+}
+
+export function pointsBounds(points: number[]): { x: number; y: number; w: number; h: number } {
+  if (points.length < 2) return { x: 0, y: 0, w: 1, h: 1 };
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (let i = 0; i < points.length; i += 2) {
+    const x = points[i];
+    const y = points[i + 1];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+  return {
+    x: minX,
+    y: minY,
+    w: Math.max(1, maxX - minX),
+    h: Math.max(1, maxY - minY),
+  };
+}
+
+/**
+ * Bounding box for a stroke considering its kind (rect/ellipse use first 2 points
+ * as opposite corners; pen/line/arrow use the actual point list).
+ */
+export function strokeGeometryBounds(s: Pick<StrokeData, 'kind' | 'points'>): { x: number; y: number; w: number; h: number } {
+  if (s.kind === 'rect' || s.kind === 'ellipse') {
+    if (s.points.length < 4) return pointsBounds(s.points);
+    const [x1, y1, x2, y2] = s.points;
+    const x = Math.min(x1, x2);
+    const y = Math.min(y1, y2);
+    return { x, y, w: Math.max(1, Math.abs(x2 - x1)), h: Math.max(1, Math.abs(y2 - y1)) };
+  }
+  return pointsBounds(s.points);
+}
+
+function distToSegment(px: number, py: number, x1: number, y1: number, x2: number, y2: number): number {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(px - x1, py - y1);
+  let t = ((px - x1) * dx + (py - y1) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const cx = x1 + t * dx;
+  const cy = y1 + t * dy;
+  return Math.hypot(px - cx, py - cy);
+}
+
+export function strokeHit(s: Pick<StrokeData, 'kind' | 'points' | 'size' | 'filled'>, x: number, y: number, threshold: number): boolean {
+  const t = threshold + s.size / 2;
+  if (s.kind === 'pen' || s.kind === 'line' || s.kind === 'arrow') {
+    if (s.points.length < 4) {
+      if (s.points.length >= 2) {
+        return Math.hypot(x - s.points[0], y - s.points[1]) <= t;
+      }
+      return false;
+    }
+    if (s.kind === 'pen') {
+      for (let i = 0; i < s.points.length - 2; i += 2) {
+        if (distToSegment(x, y, s.points[i], s.points[i + 1], s.points[i + 2], s.points[i + 3]) <= t) return true;
+      }
+      return false;
+    }
+    return distToSegment(x, y, s.points[0], s.points[1], s.points[2], s.points[3]) <= t;
+  }
+  const b = strokeGeometryBounds(s as StrokeData);
+  if (s.kind === 'rect') {
+    const inside = x >= b.x - t && x <= b.x + b.w + t && y >= b.y - t && y <= b.y + b.h + t;
+    if (!inside) return false;
+    if (s.filled) return x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h;
+    const onLeft = Math.abs(x - b.x) <= t && y >= b.y - t && y <= b.y + b.h + t;
+    const onRight = Math.abs(x - (b.x + b.w)) <= t && y >= b.y - t && y <= b.y + b.h + t;
+    const onTop = Math.abs(y - b.y) <= t && x >= b.x - t && x <= b.x + b.w + t;
+    const onBottom = Math.abs(y - (b.y + b.h)) <= t && x >= b.x - t && x <= b.x + b.w + t;
+    return onLeft || onRight || onTop || onBottom;
+  }
+  if (s.kind === 'ellipse') {
+    const cx = b.x + b.w / 2;
+    const cy = b.y + b.h / 2;
+    const rx = b.w / 2;
+    const ry = b.h / 2;
+    if (rx <= 0 || ry <= 0) return false;
+    const norm = ((x - cx) * (x - cx)) / (rx * rx) + ((y - cy) * (y - cy)) / (ry * ry);
+    if (s.filled) return norm <= 1;
+    const eps = Math.max(0.05, t / Math.min(rx, ry));
+    return norm >= 1 - eps && norm <= 1 + eps;
+  }
+  return false;
+}

--- a/src/lib/study/yDocHelpers.ts
+++ b/src/lib/study/yDocHelpers.ts
@@ -8,6 +8,7 @@ export function getEdgesMap(doc: Y.Doc): Y.Map<Y.Map<any>> {
   return doc.getMap('edges');
 }
 
+
 export function nodeFromYMap(id: string, m: Y.Map<any>) {
   const node: any = {
     id: m.get('id') ?? id,


### PR DESCRIPTION
## Summary
- Adds a freehand drawing tool to the study canvas (pen/line/arrow/rect/ellipse, color/size/filled controls, eraser, keyboard shortcuts D/E/[/]/1-6, space-to-pan).
- Strokes are stored as `drawing` nodes on the Yjs doc so they get native React Flow selection, move and resize.
- Repoints the Tauri auto-updater endpoint to `Tulia-Study/tulia-bible` after the repo move.

## Test plan
- [ ] Open a study session, switch to the draw tool (D), draw with each brush kind, change color (1-6) and size ([ / ]).
- [ ] Hold space while drawing — canvas should pan, not draw.
- [ ] Erase strokes with the eraser tool (E).
- [ ] Move/resize a stroke with the select tool; confirm it stays correct shape.
- [ ] Two clients: strokes sync over Yjs in real time.
- [ ] Bump version, cut a release, install an older build, confirm it pulls the new `latest.json` from `Tulia-Study/tulia-bible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)