### PR TITLE
OAuth in system browser, fix Windows logout on relaunch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hocuspocus/provider": "^2.15.3",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.3
         version: 2.5.3
@@ -480,6 +483,9 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
     engines: {node: '>= 10'}
@@ -550,6 +556,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
@@ -2172,6 +2181,8 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.0': {}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     optional: true
 
@@ -2218,6 +2229,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,13 +77,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.1.4"
+version = "0.3.0"
 dependencies = [
  "log",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -610,6 +611,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +718,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -922,6 +949,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1616,6 +1652,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2581,6 +2623,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,6 +3396,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4246,6 +4308,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4537,6 +4620,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5400,6 +5492,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2.3.1"
+tauri-plugin-deep-link = "2.4.9"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "process:default"
+    "process:default",
+    "deep-link:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let builder = tauri::Builder::default()
+    .plugin(tauri_plugin_deep_link::init())
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_process::init());
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,14 @@
     "createUpdaterArtifacts": true
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["tulia"]
+      },
+      "mobile": [
+        { "scheme": "tulia", "host": "auth" }
+      ]
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI3NzJEQ0JCRkYzRUEyMjgKUldRb29qNy91OXh5SjMrRmtDaElxWE9zM3Nyc21ISlZBSVYycTBaazZ6M1EzekNidUZ5ZmphdWUK",
       "endpoints": [

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { isTauri } from '@tauri-apps/api/core'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { cn } from '@/lib/cn'
@@ -188,7 +190,19 @@ export function AuthModal({ open, onClose, initialMode = 'login' }: AuthModalPro
 
           <button
             type="button"
-            onClick={() => { window.location.href = `${API_BASE}/api/auth/google/redirect` }}
+            onClick={() => {
+              // In Tauri we open the system browser instead of navigating
+              // the webview. That way Google can use the user's existing
+              // session and they don't have to re-type credentials. The
+              // backend honors `?client=desktop` and redirects to the
+              // `tulia://auth/finish` deep link, which the app receives
+              // via tauri-plugin-deep-link.
+              if (isTauri()) {
+                void openUrl(`${API_BASE}/api/auth/google/redirect?client=desktop`)
+              } else {
+                window.location.href = `${API_BASE}/api/auth/google/redirect`
+              }
+            }}
             className="flex w-full items-center justify-center gap-2.5 bg-bg-tertiary border border-border-subtle rounded-lg py-2.5 text-sm font-medium text-text-primary hover:border-accent/40 transition-colors duration-150 mb-3"
           >
             <svg width="16" height="16" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/src/lib/deepLink.ts
+++ b/src/lib/deepLink.ts
@@ -1,0 +1,45 @@
+import { isTauri } from '@tauri-apps/api/core'
+import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link'
+
+type Navigate = (to: string, opts?: { replace?: boolean }) => void
+
+/**
+ * Forwards `tulia://auth/finish?...` deep links to the in-app
+ * `/auth/google/finish?...` route, where GoogleFinishRoute already
+ * handles `#token=` and `?error=`. Any other scheme paths are ignored.
+ *
+ * Listens both to URLs the app is launched with (cold start) and to
+ * URLs received while running.
+ */
+export function registerAuthDeepLink(navigate: Navigate): () => void {
+  if (!isTauri()) return () => {}
+
+  const handle = (url: string) => {
+    try {
+      const parsed = new URL(url)
+      if (parsed.protocol !== 'tulia:') return
+      if (parsed.host !== 'auth' || parsed.pathname !== '/finish') return
+      navigate(`/auth/google/finish${parsed.search}${parsed.hash}`, { replace: true })
+    } catch {
+      // not a valid URL — ignore
+    }
+  }
+
+  let unlisten: (() => void) | undefined
+
+  void getCurrent()
+    .then((urls) => {
+      if (urls && urls.length > 0) handle(urls[0])
+    })
+    .catch(() => {})
+
+  void onOpenUrl((urls) => {
+    if (urls && urls.length > 0) handle(urls[0])
+  }).then((fn) => {
+    unlisten = fn
+  })
+
+  return () => {
+    unlisten?.()
+  }
+}

--- a/src/lib/store/__tests__/useAuthStore.test.ts
+++ b/src/lib/store/__tests__/useAuthStore.test.ts
@@ -52,12 +52,21 @@ describe('useAuthStore', () => {
     expect(useAuthStore.getState().loading).toBe(false)
   })
 
-  it('init clears token and sets loading=false on error', async () => {
+  it('init clears token on 401 (token rejected by server)', async () => {
     localStorage.setItem('verbum_token', 'bad-token')
-    mockApi.get.mockRejectedValueOnce(new Error('Unauthorized'))
+    const err = Object.assign(new Error('Unauthorized'), { status: 401 })
+    mockApi.get.mockRejectedValueOnce(err)
     await useAuthStore.getState().init()
     expect(useAuthStore.getState().loading).toBe(false)
     expect(localStorage.getItem('verbum_token')).toBeNull()
+  })
+
+  it('init keeps token on network/transient error', async () => {
+    localStorage.setItem('verbum_token', 'good-token')
+    mockApi.get.mockRejectedValueOnce(new Error('Network down'))
+    await useAuthStore.getState().init()
+    expect(useAuthStore.getState().loading).toBe(false)
+    expect(localStorage.getItem('verbum_token')).toBe('good-token')
   })
 
   it('login sets token and user', async () => {

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -37,8 +37,15 @@ export const useAuthStore = create<AuthState>((set) => ({
       await applyUserSettings(settings)
       set({ user, loading: false })
       void hydrateUserSession()
-    } catch {
-      clearToken()
+    } catch (e) {
+      // Only nuke the token when the server explicitly rejects it.
+      // Network errors, 5xx, or backend-down on cold start used to
+      // log the user out — particularly visible on Windows/WebView2
+      // where the network can be slow to come up after launch.
+      const status = (e as { status?: number })?.status
+      if (status === 401) {
+        clearToken()
+      }
       set({ loading: false })
     }
   },

--- a/src/router/RootLayout.tsx
+++ b/src/router/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { CommandPalette } from '@/components/ui/CommandPalette'
 import { Toast } from '@/components/ui/Toast'
@@ -18,12 +18,14 @@ import { useBookmarkStore } from '@/lib/store/useBookmarkStore'
 import { useFriendStore } from '@/lib/store/useFriendStore'
 import { useChatStore } from '@/lib/store/useChatStore'
 import { checkForAppUpdates } from '@/lib/updater'
+import { registerAuthDeepLink } from '@/lib/deepLink'
 
 const VISITED_STORAGE_KEY = 'verbum_has_visited'
 let hasLoggedStartupSettings = false
 
 export function RootLayout() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const openCommandPalette = useUIStore(s => s.openCommandPalette)
   const authModalOpen      = useUIStore(s => s.authModalOpen)
   const closeAuthModal     = useUIStore(s => s.closeAuthModal)
@@ -103,6 +105,10 @@ export function RootLayout() {
       failed: t('updater.failed'),
     })
   }, [addToast, t])
+
+  useEffect(() => {
+    return registerAuthDeepLink((to, opts) => navigate(to, opts))
+  }, [navigate])
 
   useEffect(() => {
     if (!user) {


### PR DESCRIPTION
## Summary
Two fixes that landed together because they're both around auth UX in the Tauri build.

### 1. Google sign-in opens in the system browser
Today the "Sign in with Google" button does `window.location.href = .../api/auth/google/redirect`, which loads the OAuth URL inside the Tauri webview. The webview has no shared cookies with the user's default browser, so a user who's already signed in to Google in Chrome/Safari/etc still has to retype their credentials.

This PR:
- Registers the `tulia://` scheme via `tauri-plugin-deep-link` (config in \`tauri.conf.json\`, capability granted, plugin registered in \`lib.rs\`).
- Adds \`src/lib/deepLink.ts\` — listens for both cold-start and runtime deep links, forwards \`tulia://auth/finish?...\` to the in-app \`/auth/google/finish\` route which already knows how to extract the token.
- In \`AuthModal\`, gates the OAuth click: in Tauri builds, opens the URL in the system browser (with \`?client=desktop\`) via \`tauri-plugin-opener\`. Web flow is unchanged.

Pairs with backend PR (Tulia-Study/tulia-backend#X) which adds the \`client\` param and the \`tulia://auth/finish\` redirect.

### 2. Stop logging users out on cold start
\`useAuthStore.init()\` used to call \`clearToken()\` on any error from \`/api/user\` — including network failures. On Windows in particular, WebView2 can take a moment to come up after launch, so the first \`/api/user\` call could fail and the user appeared logged out every relaunch. Now we only clear the token on an explicit 401.

This is platform-agnostic — every cold start where the API is briefly unreachable benefited from this.

## Test plan

### OAuth in system browser
- [ ] Web: click Sign in with Google → unchanged flow, lands logged in.
- [ ] Tauri (mac/Win/Linux): click → system browser opens → Google sees existing session → click Allow → app receives \`tulia://auth/finish#token=...\` → user is logged in inside the app.
- [ ] Tauri while signed out of Google in browser: full normal Google flow still works.
- [ ] Cancel on Google's screen → app receives \`?error=oauth_failed\`, shows toast.

### Auth persistence
- [ ] Log in, close the app, kill network, reopen — user is still signed in (no logout, no toast).
- [ ] Log in, server returns 401 for /api/user → user is logged out (token nuked).
- [ ] Existing test \`init keeps token on network/transient error\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)