### PR TITLE
Fix Android build: deep-link mobile scheme must be an array

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
         "schemes": ["tulia"]
       },
       "mobile": [
-        { "scheme": "tulia", "host": "auth" }
+        { "host": "auth", "scheme": ["tulia"] }
       ]
     },
     "updater": {


### PR DESCRIPTION
## Summary
Hotfix for the Android release build. \`tauri-plugin-deep-link\`'s mobile entries deserialize \`scheme\` as \`Vec<String>\`, not a single string. The current main fails to build for Android with:

\`\`\`
failed to parse configuration: Error("invalid type: string \"tulia\", expected a sequence", line: 1, column: 60)
\`\`\`

Was introduced in #66 — the desktop \`schemes\` field is plural+array, so I assumed the mobile equivalent was singular+string. It isn't.

## Fix
\`\`\`json
- { "scheme": "tulia", "host": "auth" }
+ { "host": "auth", "scheme": ["tulia"] }
\`\`\`

Single character JSON change. Desktop config and runtime behavior unchanged.

## Test plan
- [ ] Android release workflow gets past \`cargo build\`.
- [ ] Desktop builds still succeed (no schema change there).
- [ ] OAuth deep link still works on a desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)