### PR TITLE
Publish AAB to Play Store closed testing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,16 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           files: android-out/*
 
+      - name: Publish to Google Play (closed testing)
+        if: github.event_name == 'release'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: study.tulia.bible
+          releaseFiles: android-out/*.aab
+          track: alpha
+          status: completed
+
   web:
     needs: bump-version
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
After the GitHub Release upload step in the Android job, push the universal \`.aab\` to the Play Store **closed testing (alpha)** track using the Play Developer API.

The service account credentials live in the new \`PLAY_SERVICE_ACCOUNT_JSON\` secret (already configured).

## Why closed testing, not production
Promotion to production stays manual. Catching a bad build in closed testing and pulling it from the console is much cheaper than rolling back a published prod release. When we're ready to go GA, either flip \`track: production\` here or add a separate manual workflow that promotes the latest closed build.

## Track name caveat
This uses \`track: alpha\` — the default name Play assigns to the first closed testing track. If your closed track was renamed in the console (e.g. "beta-testers", "qa"), update the \`track:\` value to match. The API is exact-match; mismatches return 404.

## What this doesn't do (yet)
- No release notes (\`whatsNewDirectory\`). Add later if we want per-locale notes synced from the repo.
- No staged rollout (\`userFraction\`). Closed testing doesn't really benefit from it; we'll add it when we move to production.
- No retry on transient API errors. Plan A is "rerun the job"; Plan B if it gets noisy is to add \`continue-on-error\` so a Play API blip doesn't fail the whole release.

## Test plan
- [ ] Cut a new release tag.
- [ ] Confirm the \`android\` job still uploads to GitHub Release first (so artifacts are preserved even if Play upload fails).
- [ ] Confirm the AAB shows up in Play Console → Tulia Bible → Closed testing → Alpha → Releases as a new release with the bumped versionCode.
- [ ] Testers in the closed track receive the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)