### PR TITLE
Respect mobile safe-area in sticky reading toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Tulia Bible — Collaborative Bible Study</title>
     <meta name="description" content="Read, study, and discuss the Bible collaboratively. Cross-references, highlights, notes, and real-time study sessions with friends." />
     <meta name="keywords" content="Bible, Bible study, collaborative Bible, Scripture, Christian, study app, Tulia" />

--- a/src/components/verse/VerseList.tsx
+++ b/src/components/verse/VerseList.tsx
@@ -565,7 +565,7 @@ export function VerseList() {
         <div className="flex-1 overflow-y-auto no-scrollbar relative">
 
           {/* Mobile keeps navigation/display primary; study tools appear after selecting a verse. */}
-          <div className="sticky top-0 z-10 bg-bg-secondary pointer-events-none">
+          <div className="sticky top-0 z-10 bg-bg-secondary pointer-events-none pt-[env(safe-area-inset-top)]">
             <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border-subtle px-3 py-2 md:border-b-0 md:bg-transparent md:px-4 md:py-2">
               <div className="hidden md:block pointer-events-auto">
                 <PresenceAvatars users={others} />


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to the viewport meta so `env(safe-area-inset-*)` resolves to real values on iOS / Android edge-to-edge.
- Pad the sticky Prev/Next + reading-mode toolbar in `VerseList` with `pt-[env(safe-area-inset-top)]` so it sits below the status bar on mobile.

Without this, the toolbar overlapped the system status bar (clock / icons) in the Tauri Android app and in iOS PWA mode (status bar style is `black-translucent`).

## Test plan
- [ ] Open the app on Android (Tauri) — toolbar no longer overlaps the status bar.
- [ ] Open as iOS PWA — same.
- [ ] Desktop / non-mobile web unchanged (inset resolves to 0).