### PR TITLE
Add "Export as text" button to study mode top bar

### DIFF
--- a/src/components/study/StudyMode.tsx
+++ b/src/components/study/StudyMode.tsx
@@ -179,7 +179,7 @@ export function StudyMode() {
 
   return (
     <div className="fixed inset-0 z-50 bg-bg-primary flex flex-col">
-      <StudyTopBar users={users} isGuest={isGuest} />
+      <StudyTopBar users={users} isGuest={isGuest} doc={doc} />
       {isGuest && (
         <div className="h-8 bg-accent/10 border-b border-accent/20 flex items-center justify-center gap-2 shrink-0">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5 text-accent">

--- a/src/components/study/StudyTopBar.tsx
+++ b/src/components/study/StudyTopBar.tsx
@@ -1,16 +1,18 @@
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { ChevronLeft, UserPlus, MoreHorizontal, Share2, Link, Eye } from 'lucide-react'
+import { ChevronLeft, UserPlus, MoreHorizontal, Share2, Link, Eye, Download } from 'lucide-react'
+import * as Y from 'yjs'
 import { useStudyStore } from '@/lib/store/useStudyStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { paths } from '@/router/paths'
+import { exportStudyToText, studyHasContent } from '@/lib/study/exportStudy'
 import { StudyParticipants } from './StudyParticipants'
 import { InviteModal } from './InviteModal'
 import type { AwarenessUser } from '@/hooks/useStudySession'
 
-export function StudyTopBar({ users, isGuest }: { users: AwarenessUser[]; isGuest: boolean }) {
+export function StudyTopBar({ users, isGuest, doc }: { users: AwarenessUser[]; isGuest: boolean; doc: Y.Doc | null }) {
   const { t } = useTranslation();
   const navigate = useNavigate()
   const activeSession = useStudyStore(s => s.activeSession)
@@ -56,6 +58,26 @@ export function StudyTopBar({ users, isGuest }: { users: AwarenessUser[]; isGues
     await end()
     navigate('/')
   }
+
+  const handleExportText = useCallback(async () => {
+    if (!doc) {
+      addToast(t('study.topBar.exportFailed'), 'error')
+      return
+    }
+    try {
+      const session = useStudyStore.getState().activeSession
+      if (!studyHasContent(doc)) {
+        addToast(t('study.topBar.exportEmpty'), 'info')
+        return
+      }
+      const text = exportStudyToText({ doc, title: session?.title })
+      await navigator.clipboard.writeText(text)
+      addToast(t('study.topBar.exportCopied'), 'success')
+    } catch (err) {
+      console.error('[StudyTopBar] export failed', err)
+      addToast(t('study.topBar.exportFailed'), 'error')
+    }
+  }, [doc, addToast, t])
 
   const handleExit = () => {
     navigate('/')
@@ -104,6 +126,17 @@ export function StudyTopBar({ users, isGuest }: { users: AwarenessUser[]; isGues
           title="Copy share link"
         >
           <Share2 className="w-4 h-4" />
+        </button>
+      )}
+
+      {user && !isGuest && (
+        <button
+          onClick={handleExportText}
+          className="w-7 h-7 flex items-center justify-center rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+          title={t('study.topBar.exportText')}
+          aria-label={t('study.topBar.exportText')}
+        >
+          <Download className="w-4 h-4" />
         </button>
       )}
 

--- a/src/lib/study/exportStudy.ts
+++ b/src/lib/study/exportStudy.ts
@@ -1,0 +1,167 @@
+import * as Y from 'yjs';
+import { getNodesMap, getEdgesMap } from './yDocHelpers';
+
+type RawNode = {
+  id: string;
+  type: string;
+  data: any;
+  position: { x: number; y: number };
+};
+
+type LabeledNode = RawNode & { index: number; label: string };
+
+function truncate(s: string, n: number): string {
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > n ? `${flat.slice(0, n - 1)}…` : flat;
+}
+
+function labelFor(node: RawNode): string {
+  const d = node.data ?? {};
+  switch (node.type) {
+    case 'sticky':
+      return d.text ? `Nota: "${truncate(d.text, 40)}"` : 'Nota adhesiva';
+    case 'verse':
+      return d.reference ? `Versículo ${d.reference}` : 'Versículo';
+    case 'passage':
+      return d.reference ? `Pasaje ${d.reference}` : 'Pasaje';
+    case 'comment':
+      return `Comentario de ${d.authorName ?? 'desconocido'}`;
+    case 'ai-note':
+      return d.sourceReference ? `Nota IA (${d.sourceReference})` : 'Nota IA';
+    case 'drawing':
+      return 'Dibujo';
+    default:
+      return node.type;
+  }
+}
+
+function renderNode(node: LabeledNode): string | null {
+  const d = node.data ?? {};
+  const head = `[#${node.index}]`;
+  switch (node.type) {
+    case 'sticky': {
+      const color = d.color ? ` (color: ${d.color})` : '';
+      const text = (d.text ?? '').toString();
+      return `${head} Nota adhesiva${color}\n${text || '(vacía)'}`;
+    }
+    case 'verse': {
+      const ref = d.reference ?? '(sin referencia)';
+      const text = d.text ?? '(texto no cargado)';
+      return `${head} Versículo — ${ref}\n${text}`;
+    }
+    case 'passage': {
+      const ref = d.reference ?? '(sin referencia)';
+      const verses = Array.isArray(d.verses) ? d.verses : [];
+      const body = verses.length
+        ? verses.map((v: any) => `  ${v.verse}. ${v.text}`).join('\n')
+        : '  (versículos no cargados)';
+      return `${head} Pasaje — ${ref}\n${body}`;
+    }
+    case 'comment': {
+      const author = d.authorName ?? 'desconocido';
+      const date = d.createdAt ? ` · ${d.createdAt}` : '';
+      const text = d.text ?? '';
+      return `${head} Comentario de ${author}${date}\n${text}`;
+    }
+    case 'ai-note': {
+      const src = d.sourceReference ? ` (sobre ${d.sourceReference})` : '';
+      const q = d.question ?? '';
+      const a = d.answer ?? '';
+      return `${head} Nota IA${src}\nPregunta: ${q}\nRespuesta: ${a}`;
+    }
+    case 'drawing':
+      return null;
+    default:
+      return `${head} ${node.type}\n${JSON.stringify(d)}`;
+  }
+}
+
+export type ExportStudyInput = {
+  doc: Y.Doc;
+  title?: string | null;
+};
+
+export function exportStudyToText({ doc, title }: ExportStudyInput): string {
+  const nodesMap = getNodesMap(doc);
+  const edgesMap = getEdgesMap(doc);
+
+  const raw: RawNode[] = [];
+  nodesMap.forEach((m, id) => {
+    const type = (m.get('type') as string) ?? 'sticky';
+    if (type === 'drawing') return;
+    raw.push({
+      id: (m.get('id') as string) ?? id,
+      type,
+      data: m.get('data') ?? {},
+      position: (m.get('position') as { x: number; y: number }) ?? { x: 0, y: 0 },
+    });
+  });
+
+  raw.sort((a, b) => a.position.y - b.position.y || a.position.x - b.position.x);
+
+  const nodes: LabeledNode[] = raw.map((n, i) => ({
+    ...n,
+    index: i + 1,
+    label: labelFor(n),
+  }));
+
+  const byId = new Map<string, LabeledNode>();
+  nodes.forEach((n) => byId.set(n.id, n));
+
+  const lines: string[] = [];
+  lines.push(`# Estudio: ${title?.trim() || '(sin título)'}`);
+  lines.push(`Exportado: ${new Date().toISOString()}`);
+  lines.push('');
+
+  if (nodes.length === 0) {
+    lines.push('(Este estudio no tiene nodos.)');
+  } else {
+    lines.push(`## Nodos (${nodes.length})`);
+    lines.push('');
+    for (const n of nodes) {
+      const rendered = renderNode(n);
+      if (rendered) {
+        lines.push(rendered);
+        lines.push('');
+      }
+    }
+  }
+
+  const edges: { source: string; target: string; sourceHandle?: string; targetHandle?: string }[] = [];
+  edgesMap.forEach((m) => {
+    const source = m.get('source') as string | undefined;
+    const target = m.get('target') as string | undefined;
+    if (!source || !target) return;
+    edges.push({
+      source,
+      target,
+      sourceHandle: m.get('sourceHandle') as string | undefined,
+      targetHandle: m.get('targetHandle') as string | undefined,
+    });
+  });
+
+  const visible = edges.filter((e) => byId.has(e.source) && byId.has(e.target));
+  if (visible.length > 0) {
+    lines.push(`## Conexiones (${visible.length})`);
+    lines.push('');
+    for (const e of visible) {
+      const s = byId.get(e.source)!;
+      const t = byId.get(e.target)!;
+      lines.push(`[#${s.index}] ${s.label}  →  [#${t.index}] ${t.label}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}
+
+export function studyHasContent(doc: Y.Doc): boolean {
+  const nodesMap = getNodesMap(doc);
+  let hasNonDrawing = false;
+  nodesMap.forEach((m) => {
+    if (hasNonDrawing) return;
+    const type = (m.get('type') as string) ?? 'sticky';
+    if (type !== 'drawing') hasNonDrawing = true;
+  });
+  return hasNonDrawing;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,6 +158,10 @@
   "study.topBar.invite": "Invite",
   "study.topBar.more": "More",
   "study.topBar.endSession": "End Session",
+  "study.topBar.exportText": "Export as text",
+  "study.topBar.exportCopied": "Study copied to clipboard",
+  "study.topBar.exportFailed": "Could not export study",
+  "study.topBar.exportEmpty": "Study is empty",
 
   "study.start.title": "Start a Study Session",
   "study.start.type": "Type",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -158,6 +158,10 @@
   "study.topBar.invite": "Invitar",
   "study.topBar.more": "Más",
   "study.topBar.endSession": "Finalizar sesión",
+  "study.topBar.exportText": "Exportar como texto",
+  "study.topBar.exportCopied": "Estudio copiado al portapapeles",
+  "study.topBar.exportFailed": "No se pudo exportar el estudio",
+  "study.topBar.exportEmpty": "El estudio está vacío",
 
   "study.start.title": "Iniciar sesión de estudio",
   "study.start.type": "Tipo",


### PR DESCRIPTION
Generates a plain-text dump of the active study — title, every node
(sticky notes, verses, passages, comments, AI notes) sorted top-to-bottom
plus all node-to-node connections — and copies it to the clipboard so it
can be pasted into agents. Drawings are skipped.