### PR TITLE
feat: Tulia AI study assistant — /tulia chat, canvas actions, PDF context

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -221,3 +221,12 @@ body {
   animation: study-chat-ring 0.85s cubic-bezier(0.22, 1, 0.36, 1) forwards;
   pointer-events: none;
 }
+
+/* Lift the edge-label layer above nodes (selected nodes elevate to z-index
+   1000) so an edge's delete button is clickable instead of being hidden behind
+   notes/verses. Scoped inside the viewport's stacking context (the viewport
+   has a transform), so it never covers panels, the minimap, or other chrome.
+   The layer is pointer-events:none; only the edge's own controls capture clicks. */
+.react-flow__edgelabel-renderer {
+  z-index: 1001;
+}

--- a/src/components/chat/ChatThread.tsx
+++ b/src/components/chat/ChatThread.tsx
@@ -34,6 +34,7 @@ export function ChatThread({ conversation, onBack }: ChatThreadProps) {
   const loadOlder      = useChatStore(s => s.loadOlder)
   const typingEntries  = useChatStore(s => s.typing[conversation.id] ?? EMPTY_TYPING)
   const aiThinking     = useChatStore(s => s.aiThinking[conversation.id] === true)
+  const setComposerAudience = useChatStore(s => s.setComposerAudience)
   const selfId         = useAuthStore(s => s.user?.id)
 
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -119,6 +120,7 @@ export function ChatThread({ conversation, onBack }: ChatThreadProps) {
           compact={compact}
           showReceipt={showReceipt}
           conversation={conversation}
+          onContinueWithTulia={conversation.study_session_id ? () => setComposerAudience(conversation.id, 'tulia') : undefined}
         />
       ),
     })

--- a/src/components/chat/CommandPicker.tsx
+++ b/src/components/chat/CommandPicker.tsx
@@ -41,7 +41,7 @@ export function CommandPicker({ commands, activeIdx, onSelect, onHover }: Props)
               i === activeIdx ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary',
             )}
           >
-            <span className="text-sm font-mono font-medium text-accent w-8 shrink-0">
+            <span className="text-sm font-mono font-medium text-accent min-w-[3.5rem] shrink-0">
               {cmd.label}
             </span>
             <span className="text-xs text-text-muted">{t(cmd.description as any)}</span>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FileText, Paperclip, X } from 'lucide-react'
+import { FileText, Paperclip, Sparkles, X } from 'lucide-react'
 import { useChatStore } from '@/lib/store/useChatStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { useVerseStore } from '@/lib/store/useVerseStore'
@@ -16,7 +16,7 @@ import { cn } from '@/lib/cn'
 
 interface MessageInputProps {
   conversationId: number
-  /** When set, this is a study chat: "@tulia ..." also summons the assistant. */
+  /** When set, this is a study chat: "/tulia ..." also summons the assistant. */
   studySessionId?: string | null
 }
 
@@ -24,16 +24,9 @@ interface MessageInputProps {
 const IS_CMD_MODE   = /^\/\S*$/
 // /v  (with space)  → verse autocomplete mode
 const IS_VERSE_MODE = /^\/v\s/
-// "@tulia ..." anywhere → also route the message to the AI assistant.
-const HAS_TULIA_MENTION = /@tulia\b/i
-// Just the bare mention typed → offer suggestion chips.
-const IS_TULIA_HINT = /^@tulia\s*$/i
-
-const TULIA_SUGGESTIONS = [
-  'Resume lo que hay en el lienzo',
-  'Añade Juan 3:16 y explícalo',
-  'Conecta los versículos sobre el amor',
-]
+// A leading "/tulia" routes the message to the AI assistant (prefix stripped).
+// "/tulia" is also registered as a slash command, so it shows in the "/" picker.
+const TULIA_PREFIX = /^\/tulia\b\s*/i
 
 export function MessageInput({ conversationId, studySessionId = null }: MessageInputProps) {
   const { t }        = useTranslation()
@@ -43,6 +36,24 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   const addToast     = useUIStore(s => s.addToast)
   const versionId    = useVerseStore(s => s.versionId)
   const userName     = useAuthStore(s => s.user?.name ?? null)
+  const userId       = useAuthStore(s => s.user?.id)
+
+  // Sticky "Modo Tulia": when armed, every message routes to the AI assistant
+  // without a "/tulia" prefix. Only meaningful inside a study chat.
+  const setComposerAudience = useChatStore(s => s.setComposerAudience)
+  const composerAudience = useChatStore(s => s.composerAudience[conversationId])
+  const armed = !!studySessionId && composerAudience === 'tulia'
+  const arm   = () => setComposerAudience(conversationId, 'tulia')
+  const disarm = () => setComposerAudience(conversationId, 'study')
+  // Last message in the thread (to nudge back to humans if someone speaks).
+  const lastMessage = useChatStore(s => {
+    const m = s.messages[conversationId]
+    return m && m.length ? m[m.length - 1] : null
+  })
+  const [showReturnNudge, setShowReturnNudge] = useState(false)
+  // Tracks the last seen message id so the nudge only fires for messages that
+  // arrive while armed (reset per conversation below).
+  const prevLastIdRef = useRef<number | null>(null)
 
   // PDFs attached as shared context for Tulia (live in the study's Yjs doc).
   // `available` is false outside a study, hiding the attach affordance.
@@ -72,6 +83,9 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   useEffect(() => {
     setBody('')
     textareaRef.current?.focus()
+    // Reset nudge state so a stale id from a previous conversation can't misfire.
+    setShowReturnNudge(false)
+    prevLastIdRef.current = null
   }, [conversationId])
 
   // Reset command picker index when filtered list changes
@@ -101,7 +115,42 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     return () => clearTimeout(timer)
   }, [acQuery, isVerseMode, versionId])
 
+  // Focus the composer whenever Modo Tulia is (re)armed from any entry point
+  // (pill, /tulia, tapping a Tulia bubble, Cmd/Ctrl+J).
+  useEffect(() => {
+    if (armed) textareaRef.current?.focus()
+  }, [armed])
+
+  // Safety net: auto-exit Modo Tulia after ~45s idle with an empty draft, so you
+  // never stay silently pointed at the bot.
+  useEffect(() => {
+    if (!armed || body.trim() !== '') return
+    const timer = setTimeout(() => setComposerAudience(conversationId, 'study'), 45000)
+    return () => clearTimeout(timer)
+  }, [armed, body, conversationId, setComposerAudience])
+
+  // Soft nudge: if a human (not me, not Tulia) speaks while armed, gently suggest
+  // returning to the study chat — but never auto-disarm (that would re-add the
+  // friction we removed). Only fires for messages that ARRIVE while armed, not
+  // for whatever happened to be the last message when you entered the mode.
+  useEffect(() => {
+    const id = lastMessage?.id ?? null
+    const isNew = id !== prevLastIdRef.current
+    prevLastIdRef.current = id
+    if (!armed) { setShowReturnNudge(false); return }
+    if (isNew && lastMessage && !lastMessage.is_ai && lastMessage.user_id !== userId) {
+      setShowReturnNudge(true)
+    }
+  }, [armed, lastMessage, userId])
+
   const activateCommand = (cmd: ChatCommand) => {
+    // "/tulia" arms Modo Tulia (no prefix to keep typing) instead of inserting text.
+    if (cmd.trigger === 'tulia') {
+      arm()
+      setBody('')
+      textareaRef.current?.focus()
+      return
+    }
     setBody(`/${cmd.trigger} `)
     textareaRef.current?.focus()
   }
@@ -111,7 +160,6 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     setBody(ref)
     setAcResults([])
     textareaRef.current?.focus()
-    requestAnimationFrame(() => autoresize())
   }
 
   const autoresize = () => {
@@ -120,6 +168,14 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`
   }
+
+  // Keep the textarea height in sync with its content for EVERY body change —
+  // typing, programmatic inserts, and clearing on send. useLayoutEffect runs
+  // after React commits the new value to the DOM (before paint), so on send the
+  // input reliably shrinks back to one row with no flicker.
+  useLayoutEffect(() => {
+    autoresize()
+  }, [body])
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (isCmdMode) {
@@ -137,6 +193,13 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
       if (e.key === 'Escape')    { e.preventDefault(); setBody(''); setAcResults([]); return }
     }
 
+    // Esc on an empty composer exits Modo Tulia (back to the human study chat).
+    if (e.key === 'Escape' && armed && body.trim() === '') {
+      e.preventDefault()
+      disarm()
+      return
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       submit()
@@ -146,17 +209,30 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   const submit = async () => {
     const trimmed = body.trim()
     if (!trimmed || sending) return
+    // Route to Tulia when armed (sticky mode) or on a leading "/tulia".
+    const hasTuliaPrefix = !!studySessionId && TULIA_PREFIX.test(trimmed)
+    const goToTulia = !!studySessionId && (armed || hasTuliaPrefix)
+    // Drop a leading "/tulia" so neither the posted message nor the prompt shows it.
+    const outgoing = hasTuliaPrefix ? trimmed.replace(TULIA_PREFIX, '').trim() : trimmed
+    // Bare "/tulia" (no question) just arms the mode — don't post an empty message.
+    if (goToTulia && outgoing === '') {
+      arm()
+      setBody('')
+      return
+    }
     setSending(true)
     try {
-      await send(conversationId, trimmed)
-      setBody('')
-      autoresize()
-      // In a study chat, an "@tulia ..." message also summons the assistant.
-      // Fire-and-forget: it manages its own thinking indicator + bot reply.
-      // Attached documents ride along as grounding context.
-      if (studySessionId && HAS_TULIA_MENTION.test(trimmed)) {
+      await send(conversationId, outgoing)
+      setBody('') // height resets via the useLayoutEffect on [body]
+      setShowReturnNudge(false)
+      // The human message is always posted (visible to everyone). When directed
+      // at Tulia, also summon the assistant (fire-and-forget; it owns its own
+      // thinking indicator + bot reply) and LATCH sticky mode so the next turn
+      // needs no prefix. Attached documents ride along as grounding context.
+      if (goToTulia && studySessionId) {
         const documents = aiDocs.documents.map(d => ({ name: d.name, text: d.text }))
-        void askTulia(conversationId, studySessionId, trimmed, documents)
+        void askTulia(conversationId, studySessionId, outgoing, documents)
+        arm()
       }
     } catch {
       addToast(t('chat.sendFailed'), 'error')
@@ -205,14 +281,6 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     if (file) void attachPdf(file)
   }
 
-  const pickTuliaSuggestion = (s: string) => {
-    setBody(`@tulia ${s} `)
-    textareaRef.current?.focus()
-    requestAnimationFrame(autoresize)
-  }
-
-  const showTuliaHint = !!studySessionId && IS_TULIA_HINT.test(body)
-
   const handleChange = (value: string) => {
     setBody(value)
     if (value.trim().length > 0) notifyTyping(conversationId)
@@ -243,25 +311,6 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
         />
       )}
 
-      {showTuliaHint && (
-        <div className="absolute bottom-full left-3 right-3 mb-2 z-10 rounded-xl border border-border-subtle bg-surface/95 backdrop-blur shadow-lg p-2">
-          <p className="px-1.5 pb-1.5 text-2xs text-text-muted">
-            {t('study.ai.hint', 'Pregúntale a Tulia o pídele que cambie el lienzo')}
-          </p>
-          <div className="flex flex-col gap-1">
-            {TULIA_SUGGESTIONS.map((s) => (
-              <button
-                key={s}
-                type="button"
-                onClick={() => pickTuliaSuggestion(s)}
-                className="text-left text-sm text-text-secondary hover:text-text-primary rounded-lg px-2 py-1.5 hover:bg-bg-tertiary transition-colors"
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
 
       {canAttach && aiDocs.documents.length > 0 && (
         <div className="flex flex-wrap gap-1.5 pb-2">
@@ -283,6 +332,34 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
               </button>
             </span>
           ))}
+        </div>
+      )}
+
+      {armed && showReturnNudge && body.trim() !== '' && (
+        <button
+          type="button"
+          onClick={() => { disarm(); textareaRef.current?.focus() }}
+          className="mb-2 w-full flex items-center justify-center gap-1.5 rounded-lg bg-bg-tertiary/70 hover:bg-bg-tertiary px-2 py-1.5 text-2xs text-text-secondary transition-colors"
+        >
+          {t('study.chat.returnNudge', '¿Volver al estudio? Sigues escribiéndole a Tulia.')}
+        </button>
+      )}
+
+      {armed && (
+        <div className="flex items-center gap-1.5 pb-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-accent/10 border border-accent/30 pl-2 pr-1 py-0.5 text-2xs font-medium text-accent">
+            <Sparkles className="w-3 h-3" />
+            {t('study.chat.tuliaMode', 'Modo Tulia')}
+            <button
+              type="button"
+              onClick={() => { disarm(); textareaRef.current?.focus() }}
+              aria-label={t('study.chat.exitTulia', 'Salir del modo Tulia (Esc)')}
+              title={t('study.chat.exitTulia', 'Salir del modo Tulia (Esc)')}
+              className="ml-0.5 flex items-center justify-center w-4 h-4 rounded-full hover:bg-accent/20 transition-colors"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
         </div>
       )}
 
@@ -315,23 +392,25 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
         <textarea
           ref={textareaRef}
           value={body}
-          onChange={(e) => { handleChange(e.target.value); autoresize() }}
+          onChange={(e) => handleChange(e.target.value)}
           onKeyDown={handleKeyDown}
           rows={1}
-          placeholder={t('chat.messagePlaceholder')}
+          placeholder={armed ? t('study.chat.toTulia', 'Pregúntale a Tulia…') : t('chat.messagePlaceholder')}
           className={cn(
             'flex-1 resize-none bg-bg-tertiary md:bg-bg-secondary rounded-2xl md:rounded-md border border-border-subtle focus:border-border-hover',
             'text-[15px] md:text-sm text-text-primary placeholder:text-text-muted',
             'px-4 md:px-3 py-2.5 md:py-2 outline-none',
             'max-h-40',
+            armed && 'border-accent/60 focus:border-accent bg-accent/5 md:bg-accent/5',
           )}
         />
-        {/* Mobile: circular accent send button, only when there's text */}
+        {/* Mobile: circular send button, only when there's text. In Modo Tulia
+            it shows the Sparkles glyph so the target audience is unmistakable. */}
         <button
           type="button"
           onClick={submit}
           disabled={sendDisabled}
-          aria-label={t('chat.send')}
+          aria-label={armed ? t('study.chat.sendToTulia', 'Enviar a Tulia') : t('chat.send')}
           className={cn(
             'md:hidden shrink-0 h-11 w-11 rounded-full flex items-center justify-center transition-all duration-150',
             hasText
@@ -339,11 +418,15 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
               : 'bg-bg-tertiary text-text-muted scale-90 opacity-0 pointer-events-none',
           )}
         >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
-            <path d="M5 12l7-7 7 7M12 5v14" />
-          </svg>
+          {armed ? (
+            <Sparkles className="w-5 h-5" />
+          ) : (
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
+              <path d="M5 12l7-7 7 7M12 5v14" />
+            </svg>
+          )}
         </button>
-        {/* Desktop: original labelled button unchanged */}
+        {/* Desktop: labelled button — relabels to "Enviar a Tulia" when armed. */}
         <button
           type="button"
           onClick={submit}
@@ -355,10 +438,14 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
               : 'bg-accent text-bg-primary hover:brightness-110',
           )}
         >
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" className="w-3.5 h-3.5">
-            <path d="M2 8l11-5-3 11-3-4-5-2z" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-          {t('chat.send')}
+          {armed ? (
+            <Sparkles className="w-3.5 h-3.5" />
+          ) : (
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" className="w-3.5 h-3.5">
+              <path d="M2 8l11-5-3 11-3-4-5-2z" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          )}
+          {armed ? t('study.chat.sendToTulia', 'Enviar a Tulia') : t('chat.send')}
         </button>
       </div>
     </div>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -14,13 +14,15 @@ interface MessageItemProps {
   compact:      boolean
   showReceipt:  boolean
   conversation: Conversation
+  /** Present in study chats: enter "Modo Tulia" to continue this AI thread. */
+  onContinueWithTulia?: () => void
 }
 
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
 }
 
-export function MessageItem({ message, isMine, compact, showReceipt, conversation }: MessageItemProps) {
+export function MessageItem({ message, isMine, compact, showReceipt, conversation, onContinueWithTulia }: MessageItemProps) {
   const { t } = useTranslation()
   const selfId = useAuthStore(s => s.user?.id)
   const isGroup = conversation.type === 'group'
@@ -101,6 +103,18 @@ export function MessageItem({ message, isMine, compact, showReceipt, conversatio
             {timeLabel}
           </span>
         </div>
+
+        {/* Continue this AI exchange without re-typing "/tulia" (study chats). */}
+        {isAi && onContinueWithTulia && (
+          <button
+            type="button"
+            onClick={onContinueWithTulia}
+            className="group/cont mt-1 px-1 inline-flex items-center gap-1 text-2xs text-text-muted hover:text-accent transition-colors"
+          >
+            <Sparkles className="w-3 h-3 opacity-60 group-hover/cont:opacity-100" />
+            {t('study.chat.continueTulia', 'Seguir con Tulia')}
+          </button>
+        )}
 
         {/* Receipt sits as a quiet status below — only on mobile under the last sent message */}
         {showReceipt && receiptLabel && (

--- a/src/components/chat/chatCommands.ts
+++ b/src/components/chat/chatCommands.ts
@@ -6,6 +6,11 @@ export interface ChatCommand {
 
 export const CHAT_COMMANDS: ChatCommand[] = [
   {
+    trigger:     'tulia',
+    label:       '/tulia',
+    description: 'chat.commandTuliaDesc',
+  },
+  {
     trigger:     'v',
     label:       '/v',
     description: 'chat.commandVerseDesc',

--- a/src/components/study/StudyCanvas.tsx
+++ b/src/components/study/StudyCanvas.tsx
@@ -1362,6 +1362,7 @@ useEffect(() => {
           deleteKeyCode={['Backspace', 'Delete']}
           multiSelectionKeyCode="Shift"
           selectionKeyCode="Shift"
+          elevateEdgesOnSelect
           className={`bg-bg-secondary${
             tool === 'draw' || tool === 'erase'
               ? spaceHeld

--- a/src/components/study/StudyChatWidget.tsx
+++ b/src/components/study/StudyChatWidget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { MessageSquare } from 'lucide-react'
+import { MessageSquare, Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
 import { chatApi, type ChatMessage, type Conversation } from '@/lib/chatApi'
@@ -22,7 +22,7 @@ interface StudyChatWidgetProps {
  * surface so threading, typing, receipts, and history all come for free.
  *
  * This is the single chat surface for a study: human messages plus the Tulia
- * AI assistant, summoned inline by mentioning "@tulia".
+ * AI assistant, summoned inline with the "/tulia" command.
  */
 export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenChange }: StudyChatWidgetProps) {
   const { t } = useTranslation()
@@ -31,6 +31,8 @@ export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenCh
   const conversations = useChatStore(s => s.conversations)
   const messages = useChatStore(s => s.messages[conversationId] ?? EMPTY_MESSAGES)
   const markRead = useChatStore(s => s.markRead)
+  // When "Modo Tulia" is armed, the bubble becomes an AI (Sparkles) icon.
+  const tuliaArmed = useChatStore(s => s.composerAudience[conversationId]) === 'tulia'
 
   const [conversation, setConversation] = useState<Conversation | null>(null)
   const [internalOpen, setInternalOpen] = useState(false)
@@ -121,10 +123,10 @@ export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenCh
             open && 'scale-95',
             !open && pingKey > 0 && 'study-chat-bouncing',
           )}
-          aria-label={t('study.chat.toggle', 'Toggle chat')}
-          title={t('study.chat.toggle', 'Toggle chat')}
+          aria-label={tuliaArmed ? t('study.chat.tuliaMode', 'Modo Tulia') : t('study.chat.toggle', 'Toggle chat')}
+          title={tuliaArmed ? t('study.chat.tuliaMode', 'Modo Tulia') : t('study.chat.toggle', 'Toggle chat')}
         >
-          <MessageSquare className="w-5 h-5" />
+          {tuliaArmed ? <Sparkles className="w-5 h-5" /> : <MessageSquare className="w-5 h-5" />}
           {unread > 0 && (
             <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-2xs font-medium flex items-center justify-center border-2 border-bg-primary">
               {unread > 99 ? '99+' : unread}

--- a/src/components/study/StudyMode.tsx
+++ b/src/components/study/StudyMode.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStudyStore } from '@/lib/store/useStudyStore'
+import { useChatStore } from '@/lib/store/useChatStore'
 import { useAuthStore } from '@/lib/store/useAuthStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 import { useStudySession } from '@/hooks/useStudySession'
@@ -98,6 +99,18 @@ export function StudyMode() {
       if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
         e.preventDefault()
         getActions()?.undo?.()
+        return
+      }
+
+      // Cmd/Ctrl+J: jump into "Modo Tulia" — open the chat and arm the composer
+      // so you can talk to the AI without typing "/tulia". Works while typing.
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'j' || e.key === 'J')) {
+        e.preventDefault()
+        const convId = useStudyStore.getState().activeSession?.conversation_id
+        if (convId) {
+          setChatOpen(true)
+          useChatStore.getState().setComposerAudience(convId, 'tulia')
+        }
         return
       }
 

--- a/src/components/study/StudyToolbar.tsx
+++ b/src/components/study/StudyToolbar.tsx
@@ -147,7 +147,7 @@ export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsert
             />
           </Tooltip>
 
-          {/* Chat (human + Tulia AI via @tulia) */}
+          {/* Chat (human + Tulia AI via /tulia) */}
           <Tooltip label={t('study.toolbar.chat', 'Chat (A)')} side="right">
             <ToolbarButton
               icon={<MessageSquare className="w-4 h-4" />}

--- a/src/components/study/edges/ArrowEdge.tsx
+++ b/src/components/study/edges/ArrowEdge.tsx
@@ -47,7 +47,10 @@ export function ArrowEdge({
           className="nodrag nopan absolute flex items-center gap-1.5"
           style={{
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-            pointerEvents: 'all',
+            // The label layer sits above nodes (z-index 1001) so the delete
+            // button is reachable; keep it click-through so it doesn't block
+            // clicks on the nodes underneath — only the button re-enables clicks.
+            pointerEvents: 'none',
           }}
         >
           {data?.label != null && (
@@ -62,7 +65,7 @@ export function ArrowEdge({
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') removeEdge(e);
               }}
-              className="flex items-center justify-center w-5 h-5 rounded-full bg-surface border border-border text-text-muted hover:text-text-primary hover:border-border-strong shadow-sm"
+              className="pointer-events-auto cursor-pointer flex items-center justify-center w-5 h-5 rounded-full bg-surface border border-border text-text-muted hover:text-text-primary hover:border-border-strong shadow-sm"
               aria-label="Remove edge"
               title="Remove edge"
             >

--- a/src/lib/aiApi.ts
+++ b/src/lib/aiApi.ts
@@ -39,7 +39,7 @@ export interface AiCanvasContextEdge {
 }
 
 /**
- * Invoke the study assistant from the unified study chat ("@tulia ..."). The
+ * Invoke the study assistant from the unified study chat ("/tulia ..."). The
  * server builds the conversation context itself; the client sends the prompt
  * (mention already stripped is fine too), the linked conversation, and the
  * current canvas snapshot (which only the client can see).

--- a/src/lib/store/useChatStore.ts
+++ b/src/lib/store/useChatStore.ts
@@ -23,6 +23,13 @@ type ChatState = {
   typing:        Record<number, TypingEntry[]>
   /** Per-conversation flag: Tulia (AI) is generating a reply right now. */
   aiThinking:    Record<number, boolean>
+  /**
+   * Per-conversation composer audience. 'tulia' = sticky "Modo Tulia": every
+   * message is routed to the AI assistant without a "/tulia" prefix until the
+   * user exits. Default (absent) = 'study' (the human group). Local/UI only —
+   * never synced to other participants.
+   */
+  composerAudience: Record<number, 'study' | 'tulia'>
 
   load: () => Promise<void>
   select: (id: number | null) => Promise<void>
@@ -30,6 +37,7 @@ type ChatState = {
   loadOlder: (id: number) => Promise<void>
   send: (id: number, body: string) => Promise<void>
   askTulia: (id: number, sessionId: string, prompt: string, documents?: AiContextDocument[]) => Promise<void>
+  setComposerAudience: (id: number, audience: 'study' | 'tulia') => void
   markRead: (id: number) => Promise<void>
   notifyTyping: (id: number) => void
   listenForUpdates: (userId: number) => void
@@ -166,6 +174,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadingThread: {},
   typing:        {},
   aiThinking:    {},
+  composerAudience: {},
 
   load: async () => {
     set({ loadingList: true })
@@ -245,7 +254,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     })
   },
 
-  // Invoke the Tulia AI assistant for a study conversation. The human "@tulia"
+  // Invoke the Tulia AI assistant for a study conversation. The human "/tulia"
   // message has already been sent; this runs the grounded loop server-side,
   // appends Tulia's persisted reply, and applies any canvas mutations. Other
   // participants receive the reply over the normal realtime channel.
@@ -310,6 +319,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set((s) => ({ aiThinking: { ...s.aiThinking, [id]: false } }))
     }
   },
+
+  setComposerAudience: (id, audience) =>
+    set((s) => ({ composerAudience: { ...s.composerAudience, [id]: audience } })),
 
   markRead: async (id) => {
     try {
@@ -410,6 +422,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
     subscribed.clear()
     privateChannelName = null
-    set({ conversations: [], selectedId: null, messages: {}, typing: {}, aiThinking: {} })
+    set({ conversations: [], selectedId: null, messages: {}, typing: {}, aiThinking: {}, composerAudience: {} })
   },
 }))

--- a/src/lib/study/yDocHelpers.ts
+++ b/src/lib/study/yDocHelpers.ts
@@ -11,7 +11,7 @@ export function getEdgesMap(doc: Y.Doc): Y.Map<Y.Map<any>> {
 // --- Attached AI context documents (shared across all study participants) ---
 // Extracted text of PDFs a participant shared as grounding context for Tulia.
 // They live in the Yjs doc so everyone sees the same attachments and anyone's
-// "@tulia" question carries them. They are NEVER auto-added to the canvas.
+// "/tulia" question carries them. They are NEVER auto-added to the canvas.
 export interface StoredAiDocument {
   id: string;
   name: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -149,7 +149,6 @@
   "study.toolbar.unlock": "Unlock",
   "study.toolbar.chat": "Chat (A)",
 
-  "study.ai.hint": "Ask Tulia, or have it change the canvas",
   "study.ai.errorVerify": "Verify your email to use Tulia.",
   "study.ai.errorBudget": "You've reached this month's AI limit.",
   "study.ai.errorGeneric": "Couldn't reach Tulia. Try again.",
@@ -164,6 +163,12 @@
   "study.chat.toggle": "Toggle study chat",
   "study.chat.close": "Close",
   "study.chat.minimize": "Minimize",
+  "study.chat.tuliaMode": "Tulia mode",
+  "study.chat.toTulia": "Ask Tulia…",
+  "study.chat.sendToTulia": "Send to Tulia",
+  "study.chat.exitTulia": "Exit Tulia mode (Esc)",
+  "study.chat.continueTulia": "Continue with Tulia",
+  "study.chat.returnNudge": "Back to the study? You're still messaging Tulia.",
 
   "study.topBar.exit": "Exit",
   "study.topBar.invite": "Invite",
@@ -395,6 +400,7 @@
   "chat.commandInsert": "↵ insert",
   "chat.commandClose": "Esc close",
   "chat.commandVerseDesc": "Search and insert a verse",
+  "chat.commandTuliaDesc": "Talk to Tulia (the AI)",
   "chat.conversationsEmpty": "No conversations yet. Start one from the + button.",
   "chat.empty.headline": "No conversation yet",
   "chat.empty.body": "Invite a friend or join a study to start chatting.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -149,7 +149,6 @@
   "study.toolbar.unlock": "Desbloquear",
   "study.toolbar.chat": "Chat (A)",
 
-  "study.ai.hint": "Pregúntale a Tulia o pídele que cambie el lienzo",
   "study.ai.errorVerify": "Verifica tu correo para usar a Tulia.",
   "study.ai.errorBudget": "Has alcanzado el límite de IA de este mes.",
   "study.ai.errorGeneric": "No se pudo contactar a Tulia. Intenta de nuevo.",
@@ -164,6 +163,12 @@
   "study.chat.toggle": "Mostrar chat del estudio",
   "study.chat.close": "Cerrar",
   "study.chat.minimize": "Minimizar",
+  "study.chat.tuliaMode": "Modo Tulia",
+  "study.chat.toTulia": "Pregúntale a Tulia…",
+  "study.chat.sendToTulia": "Enviar a Tulia",
+  "study.chat.exitTulia": "Salir del modo Tulia (Esc)",
+  "study.chat.continueTulia": "Seguir con Tulia",
+  "study.chat.returnNudge": "¿Volver al estudio? Sigues escribiéndole a Tulia.",
 
   "study.topBar.exit": "Salir",
   "study.topBar.invite": "Invitar",
@@ -395,6 +400,7 @@
   "chat.commandInsert": "↵ insertar",
   "chat.commandClose": "Esc cerrar",
   "chat.commandVerseDesc": "Buscar e insertar un versículo",
+  "chat.commandTuliaDesc": "Hablar con Tulia (la IA)",
   "chat.conversationsEmpty": "Sin conversaciones aún. Inicia una desde el botón +.",
   "chat.empty.headline": "Aún no hay tertulia",
   "chat.empty.body": "Invita a un amigo o únete a un estudio para empezar a conversar.",


### PR DESCRIPTION
Brings the **Tulia AI assistant** into the study experience, fully merged into the study chat.

## Highlights
- **One chat, summon AI with `/tulia`.** No separate AI panel — the study's group chat is the single surface. Type `/tulia …` (a slash command in the `/` picker) to direct a message to Tulia; she replies as a real, persisted bot message everyone sees, and can add/connect canvas nodes ("server reasons, client applies").
- **Sticky "Modo Tulia".** `/tulia` *arms* a sticky mode so a back-and-forth needs no prefix (auto-re-arms after each reply). Enter via `/tulia`, the picker, "Seguir con Tulia" under a reply, or `Cmd/Ctrl+J`; exit via `Esc`, the pill, or idle. Default audience is always the human study chat, so the AI never butts into human conversation.
- **AI bubble icon** while Modo Tulia is active.
- **PDF as context** — attach a PDF (📎) whose text grounds Tulia's answers (not auto-added to the canvas).

## Fixes / polish (this session)
- Edge **delete** now works: a selected edge + its delete button render above nodes (`elevateEdgesOnSelect` + edge-label z-index).
- Composer textarea reliably **shrinks back** to one row on send (`useLayoutEffect`).
- Command picker spacing fixed for longer commands like `/tulia`.
- Removed the in-composer suggestions hint (too heavy).

## Notes
- Frontend-only here; the matching backend (`/tulia` command handling) is pushed to `tulia-backend` `main`.
- Verified: `pnpm build` clean; `pnpm test` 184 pass (3 failures are pre-existing, unrelated `usePresenceStore` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)