### PR TITLE
chore: point production at apolos.io (API) and apolos.bible (web)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
-VITE_API_URL=https://tulia.study
-VITE_SITE_URL=https://bible.tulia.study
-VITE_HOCUSPOCUS_URL=wss://tulia.study/hocuspocus/
+VITE_API_URL=https://apolos.io
+VITE_SITE_URL=https://apolos.bible
+VITE_HOCUSPOCUS_URL=wss://apolos.io/hocuspocus/
 VITE_REVERB_APP_KEY=ozsaw3wiiiqv2abutumj
-VITE_REVERB_HOST=tulia.study
+VITE_REVERB_HOST=apolos.io
 VITE_REVERB_PORT=443
 VITE_REVERB_SCHEME=https


### PR DESCRIPTION
## Qué hace

Primer paso visible del rename **Tulia → Apolos**: `.env.production` pasa a los dominios nuevos.

| Var | Antes | Después |
|---|---|---|
| `VITE_API_URL` | `https://tulia.study` | `https://apolos.io` |
| `VITE_SITE_URL` | `https://bible.tulia.study` | `https://apolos.bible` |
| `VITE_HOCUSPOCUS_URL` | `wss://tulia.study/hocuspocus/` | `wss://apolos.io/hocuspocus/` |
| `VITE_REVERB_HOST` | `tulia.study` | `apolos.io` |

API, Hocuspocus y Reverb viajan juntos porque los tres viven en el dominio del backend.

## ⚠️ No mergear todavía

Hasta que el backend responda en `https://apolos.io`:

- [ ] Ploi: alias `apolos.io` + certificado SSL en el site del backend
- [ ] Cloudflare: A `apolos.io` → IP del server (nube gris para emitir el cert)
- [ ] `.env` de prod: `APP_URL`, `FRONTEND_URL=https://apolos.bible`, `GOOGLE_REDIRECT_URI`
- [ ] Google Cloud Console: añadir redirect URI `https://apolos.io/api/auth/google/callback`
- [ ] DNS de `apolos.bible` apuntando a Firebase (A `199.36.158.100` + TXT `hosting-site=tulia-bible`, nube gris)
- [ ] Backend desplegado con el CORS nuevo (`Tulia-Study/tulia-backend@fc2aba5`, ya en main)

Tras el merge: `pnpm deploy`. `bible.tulia.study` sigue activo como alias durante la transición.

Resto del rename (package name, Tauri config, branding UI, docs) irá en PRs aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)