### PR TITLE
chore: rename Tulia → Apolos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-> **tulia.study** — collaborative Bible study desktop app. React 18 + Vite 8 + TypeScript 5 + Tailwind 3 + Zustand 5, packaged as a Tauri 2 desktop binary. Backend is a separate Laravel API (`verbum`).
+> **Apolos** (web app `apolos.bible`, API/landing `apolos.io`) — collaborative Bible study desktop app. React 18 + Vite 8 + TypeScript 5 + Tailwind 3 + Zustand 5, packaged as a Tauri 2 desktop binary. Backend is a separate Laravel API (`verbum`). The in-app AI study assistant is also called Apolos (Acts 18:24-28).
 
 > **Note:** `CLAUDE.md` exists for Claude Code users but contains stale claims (e.g. "highlights are client-side", "AuthModal not connected"). This file is the authoritative source.
 
@@ -88,8 +88,8 @@ Books/Chapters  | Favorites / My Notes / Friends   | Verses| Study / Commentary
 
 | System | Protocol | Purpose |
 |---|---|---|
-| Hocuspocus | WebSocket (`ws://localhost:1234` / `wss://tulia.study/hocuspocus/`) | Yjs CRDT sync for collaborative study canvas (React Flow) |
-| Laravel Echo + Reverb | WebSocket (`localhost:8080` / `tulia.study:443`) | Chat messages, typing, read receipts |
+| Hocuspocus | WebSocket (`ws://localhost:1234` / `wss://apolos.io/hocuspocus/`) | Yjs CRDT sync for collaborative study canvas (React Flow) |
+| Laravel Echo + Reverb | WebSocket (`localhost:8080` / `apolos.io:443`) | Chat messages, typing, read receipts |
 | Presence channels | Reverb | Who's reading the same chapter (friends only) |
 | Firebase Cloud Messaging | HTTP | Push notifications |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,17 @@
-# Tulia
+# Apolos
 
 Spanish-first social Bible reading app. Read the Bible *with others* — friends, comments, shared feed, reading presence.
 
 **Design**: keyboard-first, minimalist, Linear-style. Every action should be reachable by keyboard; favor command palettes, shortcuts, and dense-but-quiet UI over mouse-driven affordances. Visual language follows Linear: restrained typography, subtle borders, generous whitespace, no decorative chrome.
 
-Name comes from *Tertulia* (Spanish: a social gathering to discuss books/ideas). Domain: `tulia.study`.
+Named after *Apolos* (Acts 18:24-28) — a Jew from Alexandria, *"poderoso en las Escrituras"*, taught more accurately by Priscila y Aquila. The in-app AI study assistant shares the name ("estudia con Apolos"). Domains: web app `apolos.bible`, API/landing `apolos.io`. The old `tulia.study` / `bible.tulia.study` domains are transitional aliases.
 
 ## Layout
 
 This folder contains both halves of the product. Claude is invoked from here so it can see and edit across both.
 
-- `backend/` — Laravel + Livewire + Alpine + Tailwind. Local: `https://verbum.test` via Herd (symlink in `~/Library/Application Support/Herd/config/valet/Sites/verbum`). Prod: `https://tulia.study`. SQLite at `backend/database/database.sqlite` (absolute path in `.env`).
-- `frontend/` — Tauri 2 desktop/mobile + Vite + React 18 + TypeScript + Tailwind. Package name `tulia-study`. Web build deploys to Firebase Hosting at `https://bible.tulia.study` (`pnpm deploy`). Talks to the backend over HTTP and to a Hocuspocus collab server (JWT-authed) for shared study sessions.
+- `backend/` — Laravel + Livewire + Alpine + Tailwind. Local: `https://verbum.test` via Herd (symlink in `~/Library/Application Support/Herd/config/valet/Sites/verbum`). Prod: `https://apolos.io`. SQLite at `backend/database/database.sqlite` (absolute path in `.env`).
+- `frontend/` — Tauri 2 desktop/mobile + Vite + React 18 + TypeScript + Tailwind. Package name `apolos`. Web build deploys to Firebase Hosting at `https://apolos.bible` (`pnpm deploy`). Talks to the backend over HTTP and to a Hocuspocus collab server (JWT-authed) for shared study sessions.
 
 ## Common commands
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# tulia.study
+# apolos.bible
 
 A desktop Bible study app built for focus, depth, and collaboration.
 
-> **Landing:** [tulia.study](https://tulia.study) · **Privacy:** [tulia.study/privacy](https://tulia.study/privacy) · **Terms:** [tulia.study/terms](https://tulia.study/terms) · **GitHub:** [Tulia-Study/tulia-bible](https://github.com/Tulia-Study/tulia-bible)
+> **Landing:** [apolos.io](https://apolos.io) · **Privacy:** [apolos.io/privacy](https://apolos.io/privacy) · **Terms:** [apolos.io/terms](https://apolos.io/terms) · **GitHub:** [Tulia-Study/tulia-bible](https://github.com/Tulia-Study/tulia-bible)
 
 <img width="1680" height="960" alt="Reading view with friends panel open — Genesis 1 with accepted friends visible in the sidebar" src="https://github.com/user-attachments/assets/7c0a9ca9-33ea-47bc-9cb8-3067a0514508" />
 <img width="3360" height="1918" alt="Command palette — search and jump to any book, chapter, or verse in a keystroke" src="https://github.com/user-attachments/assets/90be971d-51f7-449a-bb77-8ede0ae4b918" />
@@ -14,7 +14,13 @@ A desktop Bible study app built for focus, depth, and collaboration.
 
 I wanted to study the Bible more seriously — not just read it, but actually dig in, take notes, highlight passages, and do it together with friends online. Every tool I found was either too bloated, too simple, or not designed for the way I actually study. So I built one.
 
-tulia.study is the app I wished existed.
+Apolos is the app I wished existed.
+
+---
+
+## The name
+
+Named after **Apolos** (Acts 18:24-28) — a Jew from Alexandria, *"poderoso en las Escrituras"* (mighty in the Scriptures), who was taught more accurately "the way of God" by Priscila and Aquila and then powerfully helped the believers. The name captures both careful study and study *together*. The in-app AI study assistant shares the name: you study **with Apolos**.
 
 ---
 
@@ -66,10 +72,10 @@ In the future, some features that cost money to run — AI-powered search, exten
 
 ### macOS — first-time open
 
-The macOS builds aren't signed with an Apple Developer certificate yet (it's $99/year and the app is still early). Gatekeeper will say *"Apple could not verify Tulia Study is free of malware..."*. The code is open source — you can read every line in this repo. To open it the first time:
+The macOS builds aren't signed with an Apple Developer certificate yet (it's $99/year and the app is still early). Gatekeeper will say *"Apple could not verify Apolos is free of malware..."*. The code is open source — you can read every line in this repo. To open it the first time:
 
-- **macOS 14 and earlier**: in Finder, right-click `Tulia Study.app` → **Open**. The same warning appears, but now with an **Open** button. Only needed once.
-- **macOS 15 (Sequoia) and later**: open **System Settings → Privacy & Security**, scroll down, you'll see *"Tulia Study was blocked..."* → click **Open Anyway**.
+- **macOS 14 and earlier**: in Finder, right-click `Apolos.app` → **Open**. The same warning appears, but now with an **Open** button. Only needed once.
+- **macOS 15 (Sequoia) and later**: open **System Settings → Privacy & Security**, scroll down, you'll see *"Apolos was blocked..."* → click **Open Anyway**.
 
 After that first launch, double-clicking works normally.
 
@@ -87,7 +93,7 @@ Download the .apk from [GitHub Releases](https://github.com/Tulia-Study/tulia-bi
 
 ### Web (offline / PWA)
 
-The web version at [bible.tulia.study](https://bible.tulia.study) requires an internet connection. There is no offline/PWA support for the web client at this time — use the desktop app for the best offline experience.
+The web version at [apolos.bible](https://apolos.bible) requires an internet connection. There is no offline/PWA support for the web client at this time — use the desktop app for the best offline experience.
 
 ---
 
@@ -115,7 +121,7 @@ The backend lives in `../backend/` of this monorepo and is served locally at `ht
 
 ## Acknowledgements
 
-tulia.study is built on the shoulders of people who did the hard work of digitizing and publishing scripture openly.
+Apolos is built on the shoulders of people who did the hard work of digitizing and publishing scripture openly.
 
 **Bible texts**
 

--- a/index.html
+++ b/index.html
@@ -3,33 +3,33 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Tulia Bible — Collaborative Bible Study</title>
+    <title>Apolos Bible — Collaborative Bible Study</title>
     <meta name="description" content="Read, study, and discuss the Bible collaboratively. Cross-references, highlights, notes, and real-time study sessions with friends." />
-    <meta name="keywords" content="Bible, Bible study, collaborative Bible, Scripture, Christian, study app, Tulia" />
+    <meta name="keywords" content="Bible, Bible study, collaborative Bible, Scripture, Christian, study app, Apolos" />
     <meta name="theme-color" content="#1a1a2e" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Tulia" />
+    <meta name="apple-mobile-web-app-title" content="Apolos" />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://bible.tulia.study/" />
+    <link rel="canonical" href="https://apolos.bible/" />
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Tulia Bible — Collaborative Bible Study" />
+    <meta property="og:title" content="Apolos Bible — Collaborative Bible Study" />
     <meta property="og:description" content="Read, study, and discuss the Bible collaboratively. Cross-references, highlights, notes, and real-time study sessions with friends." />
-    <meta property="og:image" content="https://bible.tulia.study/logo.png" />
+    <meta property="og:image" content="https://apolos.bible/logo.png" />
     <meta property="og:image:width" content="799" />
     <meta property="og:image:height" content="799" />
-    <meta property="og:url" content="https://bible.tulia.study/" />
+    <meta property="og:url" content="https://apolos.bible/" />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Tulia Bible" />
+    <meta property="og:site_name" content="Apolos Bible" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Tulia Bible — Collaborative Bible Study" />
+    <meta name="twitter:title" content="Apolos Bible — Collaborative Bible Study" />
     <meta name="twitter:description" content="Read, study, and discuss the Bible collaboratively. Cross-references, highlights, notes, and real-time study sessions with friends." />
-    <meta name="twitter:image" content="https://bible.tulia.study/logo.png" />
+    <meta name="twitter:image" content="https://apolos.bible/logo.png" />
 
     <!-- Robots -->
     <meta name="robots" content="index, follow" />
@@ -46,15 +46,15 @@
     {
       "@context": "https://schema.org",
       "@type": "WebApplication",
-      "name": "Tulia Bible",
-      "url": "https://bible.tulia.study",
+      "name": "Apolos Bible",
+      "url": "https://apolos.bible",
       "description": "Collaborative Bible study app with cross-references, highlights, notes, and real-time study sessions.",
       "applicationCategory": "ReligiousApplication",
       "operatingSystem": "Web, Windows, macOS, Linux",
       "author": {
         "@type": "Organization",
-        "name": "Tulia",
-        "url": "https://bible.tulia.study"
+        "name": "Apolos",
+        "url": "https://apolos.bible"
       }
     }
     </script>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tulia-study",
+  "name": "apolos",
   "version": "0.4.0",
   "private": true,
   "scripts": {

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -95,7 +95,7 @@ messaging.onBackgroundMessage(async (payload) => {
   if (event !== 'chat_message') {
     // Other events (note_reply, friend_request, etc.) are simple — single
     // notification, no grouping. Reuse title/body from data.
-    await self.registration.showNotification(data.title || 'Tulia', {
+    await self.registration.showNotification(data.title || 'Apolos', {
       body: data.body || '',
       icon: '/pwa-192x192.png',
       badge: '/favicon.png',
@@ -106,7 +106,7 @@ messaging.onBackgroundMessage(async (payload) => {
   }
 
   const convId = String(data.conversation_id || '0')
-  const sender = data.title || 'Tulia'           // SendPushJob puts sender_name in title
+  const sender = data.title || 'Apolos'           // SendPushJob puts sender_name in title
   const bodyPreview = data.body || ''             // and body_preview in body
 
   const g = await loadGroup(convId)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://bible.tulia.study/sitemap.xml
+Sitemap: https://apolos.bible/sitemap.xml

--- a/scripts/generate-static-chapters.mjs
+++ b/scripts/generate-static-chapters.mjs
@@ -61,13 +61,13 @@ function bookUrl(slug, lang) {
 }
 
 function seoHead(bookName, slug, chapter, firstVerseText, lang) {
-  const title = `${bookName} ${chapter} — Tulia Bible`
+  const title = `${bookName} ${chapter} — Apolos Bible`
   const description = firstVerseText
     ? `${firstVerseText.slice(0, 155).trim()}`
-    : `Read ${bookName} chapter ${chapter} in Tulia Bible, the collaborative Bible study app.`
+    : `Read ${bookName} chapter ${chapter} in Apolos Bible, the collaborative Bible study app.`
   const canonical = chapterUrl(slug, chapter, lang)
   const breadcrumbs = [
-    { '@type': 'ListItem', position: 1, name: 'Tulia Bible', item: SITE_BASE },
+    { '@type': 'ListItem', position: 1, name: 'Apolos Bible', item: SITE_BASE },
     { '@type': 'ListItem', position: 2, name: bookName, item: bookUrl(slug, lang) },
     { '@type': 'ListItem', position: 3, name: `Chapter ${chapter}`, item: canonical },
   ]
@@ -78,7 +78,7 @@ function seoHead(bookName, slug, chapter, firstVerseText, lang) {
     name: title,
     description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'Tulia Bible', url: SITE_BASE },
+    isPartOf: { '@type': 'WebSite', name: 'Apolos Bible', url: SITE_BASE },
     breadcrumb: { '@type': 'BreadcrumbList', itemListElement: breadcrumbs },
   })
 
@@ -99,7 +99,7 @@ function seoHead(bookName, slug, chapter, firstVerseText, lang) {
     <meta property="og:image:width" content="799" />
     <meta property="og:image:height" content="799" />
     <meta property="og:type" content="article" />
-    <meta property="og:site_name" content="Tulia Bible" />
+    <meta property="og:site_name" content="Apolos Bible" />
     <meta property="og:locale" content="en_US" />
 
     <meta name="twitter:card" content="summary" />
@@ -170,15 +170,15 @@ function generateChapterHtml(data, lang) {
 
   html += `  <nav class="nav">\n    <span></span>\n    <span></span>\n  </nav>\n`
   html += `  <div class="footer">
-    <p>Read <a href="${chapterUrl(book.slug, chapter, lang)}">${escapeHtml(book.name)} ${chapter}</a> interactively on <a href="${SITE_BASE}">Tulia Bible</a> — with highlights, notes, cross-references, and collaborative study.</p>
+    <p>Read <a href="${chapterUrl(book.slug, chapter, lang)}">${escapeHtml(book.name)} ${chapter}</a> interactively on <a href="${SITE_BASE}">Apolos Bible</a> — with highlights, notes, cross-references, and collaborative study.</p>
   </div>\n`
   html += `</body>\n</html>\n`
   return html
 }
 
 function generateBookHtml(book, lang) {
-  const title = `${book.name} — Tulia Bible`
-  const description = `Read the book of ${book.name} (${book.chapters_count} chapters) in Tulia Bible, the collaborative Bible study app.`
+  const title = `${book.name} — Apolos Bible`
+  const description = `Read the book of ${book.name} (${book.chapters_count} chapters) in Apolos Bible, the collaborative Bible study app.`
   const canonical = bookUrl(book.slug, lang)
 
   let chapterLinks = ''
@@ -192,7 +192,7 @@ function generateBookHtml(book, lang) {
     name: title,
     description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'Tulia Bible', url: SITE_BASE },
+    isPartOf: { '@type': 'WebSite', name: 'Apolos Bible', url: SITE_BASE },
   })
 
   return `<!doctype html>
@@ -211,7 +211,7 @@ function generateBookHtml(book, lang) {
     <meta property="og:image:width" content="799" />
     <meta property="og:image:height" content="799" />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Tulia Bible" />
+    <meta property="og:site_name" content="Apolos Bible" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="${escapeHtml(title)}" />
@@ -238,7 +238,7 @@ function generateBookHtml(book, lang) {
     <ul class="chapters">
 ${chapterLinks}    </ul>
     <div class="footer">
-      <p>Read <a href="${bookUrl(book.slug, lang)}">${escapeHtml(book.name)}</a> interactively on <a href="${SITE_BASE}">Tulia Bible</a>.</p>
+      <p>Read <a href="${bookUrl(book.slug, lang)}">${escapeHtml(book.name)}</a> interactively on <a href="${SITE_BASE}">Apolos Bible</a>.</p>
     </div>
   </body>
 </html>

--- a/scripts/rename-android-build.mjs
+++ b/scripts/rename-android-build.mjs
@@ -7,8 +7,8 @@ const version = pkg.version
 const base = resolve(import.meta.dirname, '../src-tauri/gen/android/app/build/outputs')
 
 const files = [
-  { from: 'apk/universal/release/app-universal-release-unsigned.apk', to: `apk/universal/release/Tulia Study_${version}.apk` },
-  { from: 'bundle/universalRelease/app-universal-release.aab', to: `bundle/universalRelease/Tulia Study_${version}.aab` },
+  { from: 'apk/universal/release/app-universal-release-unsigned.apk', to: `apk/universal/release/Apolos_${version}.apk` },
+  { from: 'bundle/universalRelease/app-universal-release.aab', to: `bundle/universalRelease/Apolos_${version}.aab` },
 ]
 
 for (const { from, to } of files) {

--- a/src-tauri/gen/android/app/src/main/java/study/tulia/bible/TuliaMessagingService.kt
+++ b/src-tauri/gen/android/app/src/main/java/study/tulia/bible/TuliaMessagingService.kt
@@ -43,7 +43,7 @@ class TuliaMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         val data = remoteMessage.data
         val event = data["event"] ?: "tulia"
-        val title = data["title"] ?: data["sender_name"] ?: "Tulia"
+        val title = data["title"] ?: data["sender_name"] ?: "Apolos"
         val body = data["body"] ?: data["body_preview"] ?: ""
         val url = data["url"] ?: "/"
 

--- a/src-tauri/gen/android/app/src/main/res/values/strings.xml
+++ b/src-tauri/gen/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Tulia Study</string>
-    <string name="main_activity_title">Tulia Study</string>
+    <string name="app_name">Apolos</string>
+    <string name="main_activity_title">Apolos</string>
 </resources>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,7 +57,7 @@ pub fn run() {
 
             #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
             {
-                let show_item = MenuItem::with_id(app, "show", "Open Tulia", true, None::<&str>)?;
+                let show_item = MenuItem::with_id(app, "show", "Open Apolos", true, None::<&str>)?;
                 let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
                 let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "Tulia Study",
+  "productName": "Apolos",
   "version": "../package.json",
   "identifier": "study.tulia.bible",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Tulia Study",
+        "title": "Apolos",
         "width": 1280,
         "height": 800,
         "minWidth": 900,

--- a/src/components/brand/Logo.tsx
+++ b/src/components/brand/Logo.tsx
@@ -39,9 +39,9 @@ export function Logo({ symbolSize = 20, textSize = 13, className }: LogoProps) {
         className="font-reading tracking-[-0.02em] leading-none whitespace-nowrap"
         style={{ fontSize: textSize }}
       >
-        <span className="text-text-primary">tulia</span>
+        <span className="text-text-primary">apolos</span>
         <span className="text-accent">.</span>
-        <span className="text-text-primary">study</span>
+        <span className="text-text-primary">bible</span>
       </span>
     </div>
   )
@@ -61,9 +61,9 @@ export function LogoStacked({ symbolSize = 48, textSize = 22, className }: LogoS
         className="font-reading tracking-[-0.02em] leading-none whitespace-nowrap"
         style={{ fontSize: textSize }}
       >
-        <span className="text-text-primary">tulia</span>
+        <span className="text-text-primary">apolos</span>
         <span className="text-accent">.</span>
-        <span className="text-text-primary">study</span>
+        <span className="text-text-primary">bible</span>
       </span>
     </div>
   )

--- a/src/components/chat/ChatThread.tsx
+++ b/src/components/chat/ChatThread.tsx
@@ -120,7 +120,7 @@ export function ChatThread({ conversation, onBack }: ChatThreadProps) {
           compact={compact}
           showReceipt={showReceipt}
           conversation={conversation}
-          onContinueWithTulia={conversation.study_session_id ? () => setComposerAudience(conversation.id, 'tulia') : undefined}
+          onContinueWithApolos={conversation.study_session_id ? () => setComposerAudience(conversation.id, 'apolos') : undefined}
         />
       ),
     })
@@ -204,7 +204,7 @@ export function ChatThread({ conversation, onBack }: ChatThreadProps) {
 
         {aiThinking && (
           <div className="px-2 mt-1">
-            <TypingDots names={['Tulia']} />
+            <TypingDots names={['Apolos']} />
           </div>
         )}
       </div>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -16,7 +16,7 @@ import { cn } from '@/lib/cn'
 
 interface MessageInputProps {
   conversationId: number
-  /** When set, this is a study chat: "/tulia ..." also summons the assistant. */
+  /** When set, this is a study chat: "/apolos ..." also summons the assistant. */
   studySessionId?: string | null
 }
 
@@ -24,26 +24,26 @@ interface MessageInputProps {
 const IS_CMD_MODE   = /^\/\S*$/
 // /v  (with space)  → verse autocomplete mode
 const IS_VERSE_MODE = /^\/v\s/
-// A leading "/tulia" routes the message to the AI assistant (prefix stripped).
-// "/tulia" is also registered as a slash command, so it shows in the "/" picker.
-const TULIA_PREFIX = /^\/tulia\b\s*/i
+// A leading "/apolos" routes the message to the AI assistant (prefix stripped).
+// "/apolos" is also registered as a slash command, so it shows in the "/" picker.
+const APOLOS_PREFIX = /^\/apolos\b\s*/i
 
 export function MessageInput({ conversationId, studySessionId = null }: MessageInputProps) {
   const { t }        = useTranslation()
   const send         = useChatStore(s => s.send)
-  const askTulia     = useChatStore(s => s.askTulia)
+  const askApolos    = useChatStore(s => s.askApolos)
   const notifyTyping = useChatStore(s => s.notifyTyping)
   const addToast     = useUIStore(s => s.addToast)
   const versionId    = useVerseStore(s => s.versionId)
   const userName     = useAuthStore(s => s.user?.name ?? null)
   const userId       = useAuthStore(s => s.user?.id)
 
-  // Sticky "Modo Tulia": when armed, every message routes to the AI assistant
-  // without a "/tulia" prefix. Only meaningful inside a study chat.
+  // Sticky "Modo Apolos": when armed, every message routes to the AI assistant
+  // without a "/apolos" prefix. Only meaningful inside a study chat.
   const setComposerAudience = useChatStore(s => s.setComposerAudience)
   const composerAudience = useChatStore(s => s.composerAudience[conversationId])
-  const armed = !!studySessionId && composerAudience === 'tulia'
-  const arm   = () => setComposerAudience(conversationId, 'tulia')
+  const armed = !!studySessionId && composerAudience === 'apolos'
+  const arm   = () => setComposerAudience(conversationId, 'apolos')
   const disarm = () => setComposerAudience(conversationId, 'study')
   // Last message in the thread (to nudge back to humans if someone speaks).
   const lastMessage = useChatStore(s => {
@@ -55,7 +55,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   // arrive while armed (reset per conversation below).
   const prevLastIdRef = useRef<number | null>(null)
 
-  // PDFs attached as shared context for Tulia (live in the study's Yjs doc).
+  // PDFs attached as shared context for Apolos (live in the study's Yjs doc).
   // `available` is false outside a study, hiding the attach affordance.
   const aiDocs = useAiDocuments()
   const canAttach = !!studySessionId && aiDocs.available
@@ -115,13 +115,13 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     return () => clearTimeout(timer)
   }, [acQuery, isVerseMode, versionId])
 
-  // Focus the composer whenever Modo Tulia is (re)armed from any entry point
-  // (pill, /tulia, tapping a Tulia bubble, Cmd/Ctrl+J).
+  // Focus the composer whenever Modo Apolos is (re)armed from any entry point
+  // (pill, /apolos, tapping an Apolos bubble, Cmd/Ctrl+J).
   useEffect(() => {
     if (armed) textareaRef.current?.focus()
   }, [armed])
 
-  // Safety net: auto-exit Modo Tulia after ~45s idle with an empty draft, so you
+  // Safety net: auto-exit Modo Apolos after ~45s idle with an empty draft, so you
   // never stay silently pointed at the bot.
   useEffect(() => {
     if (!armed || body.trim() !== '') return
@@ -129,7 +129,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
     return () => clearTimeout(timer)
   }, [armed, body, conversationId, setComposerAudience])
 
-  // Soft nudge: if a human (not me, not Tulia) speaks while armed, gently suggest
+  // Soft nudge: if a human (not me, not Apolos) speaks while armed, gently suggest
   // returning to the study chat — but never auto-disarm (that would re-add the
   // friction we removed). Only fires for messages that ARRIVE while armed, not
   // for whatever happened to be the last message when you entered the mode.
@@ -144,8 +144,8 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   }, [armed, lastMessage, userId])
 
   const activateCommand = (cmd: ChatCommand) => {
-    // "/tulia" arms Modo Tulia (no prefix to keep typing) instead of inserting text.
-    if (cmd.trigger === 'tulia') {
+    // "/apolos" arms Modo Apolos (no prefix to keep typing) instead of inserting text.
+    if (cmd.trigger === 'apolos') {
       arm()
       setBody('')
       textareaRef.current?.focus()
@@ -193,7 +193,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
       if (e.key === 'Escape')    { e.preventDefault(); setBody(''); setAcResults([]); return }
     }
 
-    // Esc on an empty composer exits Modo Tulia (back to the human study chat).
+    // Esc on an empty composer exits Modo Apolos (back to the human study chat).
     if (e.key === 'Escape' && armed && body.trim() === '') {
       e.preventDefault()
       disarm()
@@ -209,13 +209,13 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
   const submit = async () => {
     const trimmed = body.trim()
     if (!trimmed || sending) return
-    // Route to Tulia when armed (sticky mode) or on a leading "/tulia".
-    const hasTuliaPrefix = !!studySessionId && TULIA_PREFIX.test(trimmed)
-    const goToTulia = !!studySessionId && (armed || hasTuliaPrefix)
-    // Drop a leading "/tulia" so neither the posted message nor the prompt shows it.
-    const outgoing = hasTuliaPrefix ? trimmed.replace(TULIA_PREFIX, '').trim() : trimmed
-    // Bare "/tulia" (no question) just arms the mode — don't post an empty message.
-    if (goToTulia && outgoing === '') {
+    // Route to Apolos when armed (sticky mode) or on a leading "/apolos".
+    const hasApolosPrefix = !!studySessionId && APOLOS_PREFIX.test(trimmed)
+    const goToApolos = !!studySessionId && (armed || hasApolosPrefix)
+    // Drop a leading "/apolos" so neither the posted message nor the prompt shows it.
+    const outgoing = hasApolosPrefix ? trimmed.replace(APOLOS_PREFIX, '').trim() : trimmed
+    // Bare "/apolos" (no question) just arms the mode — don't post an empty message.
+    if (goToApolos && outgoing === '') {
       arm()
       setBody('')
       return
@@ -226,12 +226,12 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
       setBody('') // height resets via the useLayoutEffect on [body]
       setShowReturnNudge(false)
       // The human message is always posted (visible to everyone). When directed
-      // at Tulia, also summon the assistant (fire-and-forget; it owns its own
+      // at Apolos, also summon the assistant (fire-and-forget; it owns its own
       // thinking indicator + bot reply) and LATCH sticky mode so the next turn
       // needs no prefix. Attached documents ride along as grounding context.
-      if (goToTulia && studySessionId) {
+      if (goToApolos && studySessionId) {
         const documents = aiDocs.documents.map(d => ({ name: d.name, text: d.text }))
-        void askTulia(conversationId, studySessionId, outgoing, documents)
+        void askApolos(conversationId, studySessionId, outgoing, documents)
         arm()
       }
     } catch {
@@ -259,7 +259,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
       })
       void send(
         conversationId,
-        t('study.ai.attached', '📄 Adjunté «{{name}}» como contexto para Tulia', { name: res.name }),
+        t('study.ai.attached', '📄 Adjunté «{{name}}» como contexto para Apolos', { name: res.name }),
       ).catch(() => {})
     } catch (e) {
       const status = (e as { status?: number } | null)?.status
@@ -267,7 +267,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
         status === 422
           ? t('study.ai.attachUnreadable', 'No pude leer ese PDF. ¿Tiene texto seleccionable?')
           : status === 403
-            ? t('study.ai.errorVerify', 'Verifica tu correo para usar a Tulia.')
+            ? t('study.ai.errorVerify', 'Verifica tu correo para usar a Apolos.')
             : t('study.ai.attachFailed', 'No se pudo adjuntar el documento.')
       addToast(msg, 'error')
     } finally {
@@ -341,7 +341,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
           onClick={() => { disarm(); textareaRef.current?.focus() }}
           className="mb-2 w-full flex items-center justify-center gap-1.5 rounded-lg bg-bg-tertiary/70 hover:bg-bg-tertiary px-2 py-1.5 text-2xs text-text-secondary transition-colors"
         >
-          {t('study.chat.returnNudge', '¿Volver al estudio? Sigues escribiéndole a Tulia.')}
+          {t('study.chat.returnNudge', '¿Volver al estudio? Sigues escribiéndole a Apolos.')}
         </button>
       )}
 
@@ -349,12 +349,12 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
         <div className="flex items-center gap-1.5 pb-2">
           <span className="inline-flex items-center gap-1.5 rounded-full bg-accent/10 border border-accent/30 pl-2 pr-1 py-0.5 text-2xs font-medium text-accent">
             <Sparkles className="w-3 h-3" />
-            {t('study.chat.tuliaMode', 'Modo Tulia')}
+            {t('study.chat.apolosMode', 'Modo Apolos')}
             <button
               type="button"
               onClick={() => { disarm(); textareaRef.current?.focus() }}
-              aria-label={t('study.chat.exitTulia', 'Salir del modo Tulia (Esc)')}
-              title={t('study.chat.exitTulia', 'Salir del modo Tulia (Esc)')}
+              aria-label={t('study.chat.exitApolos', 'Salir del modo Apolos (Esc)')}
+              title={t('study.chat.exitApolos', 'Salir del modo Apolos (Esc)')}
               className="ml-0.5 flex items-center justify-center w-4 h-4 rounded-full hover:bg-accent/20 transition-colors"
             >
               <X className="w-3 h-3" />
@@ -377,8 +377,8 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
               type="button"
               onClick={() => fileRef.current?.click()}
               disabled={extracting}
-              aria-label={t('study.ai.attachPdf', 'Adjuntar un PDF como contexto para Tulia')}
-              title={t('study.ai.attachPdf', 'Adjuntar un PDF como contexto para Tulia')}
+              aria-label={t('study.ai.attachPdf', 'Adjuntar un PDF como contexto para Apolos')}
+              title={t('study.ai.attachPdf', 'Adjuntar un PDF como contexto para Apolos')}
               className={cn(
                 'shrink-0 h-9 w-9 md:h-8 md:w-8 rounded-md flex items-center justify-center transition-colors',
                 'text-text-muted hover:text-text-primary hover:bg-bg-tertiary',
@@ -395,7 +395,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
           onChange={(e) => handleChange(e.target.value)}
           onKeyDown={handleKeyDown}
           rows={1}
-          placeholder={armed ? t('study.chat.toTulia', 'Pregúntale a Tulia…') : t('chat.messagePlaceholder')}
+          placeholder={armed ? t('study.chat.toApolos', 'Pregúntale a Apolos…') : t('chat.messagePlaceholder')}
           className={cn(
             'flex-1 resize-none bg-bg-tertiary md:bg-bg-secondary rounded-2xl md:rounded-md border border-border-subtle focus:border-border-hover',
             'text-[15px] md:text-sm text-text-primary placeholder:text-text-muted',
@@ -404,13 +404,13 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
             armed && 'border-accent/60 focus:border-accent bg-accent/5 md:bg-accent/5',
           )}
         />
-        {/* Mobile: circular send button, only when there's text. In Modo Tulia
+        {/* Mobile: circular send button, only when there's text. In Modo Apolos
             it shows the Sparkles glyph so the target audience is unmistakable. */}
         <button
           type="button"
           onClick={submit}
           disabled={sendDisabled}
-          aria-label={armed ? t('study.chat.sendToTulia', 'Enviar a Tulia') : t('chat.send')}
+          aria-label={armed ? t('study.chat.sendToApolos', 'Enviar a Apolos') : t('chat.send')}
           className={cn(
             'md:hidden shrink-0 h-11 w-11 rounded-full flex items-center justify-center transition-all duration-150',
             hasText
@@ -426,7 +426,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
             </svg>
           )}
         </button>
-        {/* Desktop: labelled button — relabels to "Enviar a Tulia" when armed. */}
+        {/* Desktop: labelled button — relabels to "Enviar a Apolos" when armed. */}
         <button
           type="button"
           onClick={submit}
@@ -445,7 +445,7 @@ export function MessageInput({ conversationId, studySessionId = null }: MessageI
               <path d="M2 8l11-5-3 11-3-4-5-2z" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           )}
-          {armed ? t('study.chat.sendToTulia', 'Enviar a Tulia') : t('chat.send')}
+          {armed ? t('study.chat.sendToApolos', 'Enviar a Apolos') : t('chat.send')}
         </button>
       </div>
     </div>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -14,15 +14,15 @@ interface MessageItemProps {
   compact:      boolean
   showReceipt:  boolean
   conversation: Conversation
-  /** Present in study chats: enter "Modo Tulia" to continue this AI thread. */
-  onContinueWithTulia?: () => void
+  /** Present in study chats: enter "Modo Apolos" to continue this AI thread. */
+  onContinueWithApolos?: () => void
 }
 
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
 }
 
-export function MessageItem({ message, isMine, compact, showReceipt, conversation, onContinueWithTulia }: MessageItemProps) {
+export function MessageItem({ message, isMine, compact, showReceipt, conversation, onContinueWithApolos }: MessageItemProps) {
   const { t } = useTranslation()
   const selfId = useAuthStore(s => s.user?.id)
   const isGroup = conversation.type === 'group'
@@ -68,7 +68,7 @@ export function MessageItem({ message, isMine, compact, showReceipt, conversatio
 
       <div className={cn('flex flex-col min-w-0 max-w-[82%] md:max-w-[75%]', isMine ? 'items-end' : 'items-start')}>
         {!compact && !isMine && (isGroup || isAi) && message.user && (
-          <span className="text-xs md:text-2xs text-text-muted mb-0.5 px-1">{isAi ? 'Tulia' : message.user.name}</span>
+          <span className="text-xs md:text-2xs text-text-muted mb-0.5 px-1">{isAi ? 'Apolos' : message.user.name}</span>
         )}
 
         <div
@@ -104,15 +104,15 @@ export function MessageItem({ message, isMine, compact, showReceipt, conversatio
           </span>
         </div>
 
-        {/* Continue this AI exchange without re-typing "/tulia" (study chats). */}
-        {isAi && onContinueWithTulia && (
+        {/* Continue this AI exchange without re-typing "/apolos" (study chats). */}
+        {isAi && onContinueWithApolos && (
           <button
             type="button"
-            onClick={onContinueWithTulia}
+            onClick={onContinueWithApolos}
             className="group/cont mt-1 px-1 inline-flex items-center gap-1 text-2xs text-text-muted hover:text-accent transition-colors"
           >
             <Sparkles className="w-3 h-3 opacity-60 group-hover/cont:opacity-100" />
-            {t('study.chat.continueTulia', 'Seguir con Tulia')}
+            {t('study.chat.continueApolos', 'Seguir con Apolos')}
           </button>
         )}
 

--- a/src/components/chat/chatCommands.ts
+++ b/src/components/chat/chatCommands.ts
@@ -6,9 +6,9 @@ export interface ChatCommand {
 
 export const CHAT_COMMANDS: ChatCommand[] = [
   {
-    trigger:     'tulia',
-    label:       '/tulia',
-    description: 'chat.commandTuliaDesc',
+    trigger:     'apolos',
+    label:       '/apolos',
+    description: 'chat.commandApolosDesc',
   },
   {
     trigger:     'v',

--- a/src/components/seo/SEOMeta.tsx
+++ b/src/components/seo/SEOMeta.tsx
@@ -12,8 +12,8 @@ export function SEOMeta() {
     url: meta.canonicalUrl,
     isPartOf: {
       '@type': 'WebSite',
-      name: 'Tulia Bible',
-      url: 'https://bible.tulia.study',
+      name: 'Apolos Bible',
+      url: 'https://apolos.bible',
     },
     breadcrumb: {
       '@type': 'BreadcrumbList',
@@ -46,7 +46,7 @@ export function SEOMeta() {
       <meta property="og:image:width" content="512" />
       <meta property="og:image:height" content="512" />
       <meta property="og:type" content="article" />
-      <meta property="og:site_name" content="Tulia Bible" />
+      <meta property="og:site_name" content="Apolos Bible" />
       <meta property="og:locale" content="en_US" />
 
       {/* Twitter Card */}

--- a/src/components/study/StudyChatWidget.tsx
+++ b/src/components/study/StudyChatWidget.tsx
@@ -21,8 +21,8 @@ interface StudyChatWidgetProps {
  * bottom-right corner of the canvas. Reuses ChatThread for the message
  * surface so threading, typing, receipts, and history all come for free.
  *
- * This is the single chat surface for a study: human messages plus the Tulia
- * AI assistant, summoned inline with the "/tulia" command.
+ * This is the single chat surface for a study: human messages plus the Apolos
+ * AI assistant, summoned inline with the "/apolos" command.
  */
 export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenChange }: StudyChatWidgetProps) {
   const { t } = useTranslation()
@@ -31,8 +31,8 @@ export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenCh
   const conversations = useChatStore(s => s.conversations)
   const messages = useChatStore(s => s.messages[conversationId] ?? EMPTY_MESSAGES)
   const markRead = useChatStore(s => s.markRead)
-  // When "Modo Tulia" is armed, the bubble becomes an AI (Sparkles) icon.
-  const tuliaArmed = useChatStore(s => s.composerAudience[conversationId]) === 'tulia'
+  // When "Modo Apolos" is armed, the bubble becomes an AI (Sparkles) icon.
+  const apolosArmed = useChatStore(s => s.composerAudience[conversationId]) === 'apolos'
 
   const [conversation, setConversation] = useState<Conversation | null>(null)
   const [internalOpen, setInternalOpen] = useState(false)
@@ -123,10 +123,10 @@ export function StudyChatWidget({ conversationId, open: controlledOpen, onOpenCh
             open && 'scale-95',
             !open && pingKey > 0 && 'study-chat-bouncing',
           )}
-          aria-label={tuliaArmed ? t('study.chat.tuliaMode', 'Modo Tulia') : t('study.chat.toggle', 'Toggle chat')}
-          title={tuliaArmed ? t('study.chat.tuliaMode', 'Modo Tulia') : t('study.chat.toggle', 'Toggle chat')}
+          aria-label={apolosArmed ? t('study.chat.apolosMode', 'Modo Apolos') : t('study.chat.toggle', 'Toggle chat')}
+          title={apolosArmed ? t('study.chat.apolosMode', 'Modo Apolos') : t('study.chat.toggle', 'Toggle chat')}
         >
-          {tuliaArmed ? <Sparkles className="w-5 h-5" /> : <MessageSquare className="w-5 h-5" />}
+          {apolosArmed ? <Sparkles className="w-5 h-5" /> : <MessageSquare className="w-5 h-5" />}
           {unread > 0 && (
             <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-2xs font-medium flex items-center justify-center border-2 border-bg-primary">
               {unread > 99 ? '99+' : unread}

--- a/src/components/study/StudyMode.tsx
+++ b/src/components/study/StudyMode.tsx
@@ -102,14 +102,14 @@ export function StudyMode() {
         return
       }
 
-      // Cmd/Ctrl+J: jump into "Modo Tulia" — open the chat and arm the composer
-      // so you can talk to the AI without typing "/tulia". Works while typing.
+      // Cmd/Ctrl+J: jump into "Modo Apolos" — open the chat and arm the composer
+      // so you can talk to the AI without typing "/apolos". Works while typing.
       if ((e.metaKey || e.ctrlKey) && (e.key === 'j' || e.key === 'J')) {
         e.preventDefault()
         const convId = useStudyStore.getState().activeSession?.conversation_id
         if (convId) {
           setChatOpen(true)
-          useChatStore.getState().setComposerAudience(convId, 'tulia')
+          useChatStore.getState().setComposerAudience(convId, 'apolos')
         }
         return
       }

--- a/src/components/study/StudyToolbar.tsx
+++ b/src/components/study/StudyToolbar.tsx
@@ -147,7 +147,7 @@ export function StudyToolbar({ tool, onToolChange, showInsertVerse, onOpenInsert
             />
           </Tooltip>
 
-          {/* Chat (human + Tulia AI via /tulia) */}
+          {/* Chat (human + Apolos AI via /apolos) */}
           <Tooltip label={t('study.toolbar.chat', 'Chat (A)')} side="right">
             <ToolbarButton
               icon={<MessageSquare className="w-4 h-4" />}

--- a/src/components/tutorial/TutorialInvite.tsx
+++ b/src/components/tutorial/TutorialInvite.tsx
@@ -16,7 +16,7 @@ export function TutorialInvite() {
   }, [showInvite])
 
   useEffect(() => {
-    ;(window as unknown as { tuliaTour?: () => void }).tuliaTour = () => {
+    ;(window as unknown as { apolosTour?: () => void }).apolosTour = () => {
       useTutorialStore.getState().reset()
     }
   }, [])

--- a/src/components/tutorial/TutorialOverlay.tsx
+++ b/src/components/tutorial/TutorialOverlay.tsx
@@ -56,7 +56,7 @@ export function TutorialOverlay() {
       if (!found) {
         if (current.target) {
           // eslint-disable-next-line no-console
-          console.warn('[Tulia tour] target not found:', current.target)
+          console.warn('[Apolos tour] target not found:', current.target)
         }
         setRect(null)
         return
@@ -149,15 +149,15 @@ export function TutorialOverlay() {
   return (
     <div className="fixed inset-0 z-50 pointer-events-none">
       <style>{`
-        @keyframes tulia-tour-pulse {
+        @keyframes apolos-tour-pulse {
           0%, 100% { box-shadow: 0 0 0 0 rgba(200,169,106,0.55), 0 0 40px 8px rgba(200,169,106,0.25); }
           50%      { box-shadow: 0 0 0 8px rgba(200,169,106,0), 0 0 60px 16px rgba(200,169,106,0.35); }
         }
-        @keyframes tulia-tour-glow {
+        @keyframes apolos-tour-glow {
           0%, 100% { opacity: 0.55; }
           50%      { opacity: 1; }
         }
-        @keyframes tulia-tour-fade-in {
+        @keyframes apolos-tour-fade-in {
           from { opacity: 0; transform: translateY(4px); }
           to   { opacity: 1; transform: translateY(0); }
         }
@@ -194,7 +194,7 @@ export function TutorialOverlay() {
               left: spotLeft,
               width: spotWidth,
               height: spotHeight,
-              animation: 'tulia-tour-pulse 2.2s ease-in-out infinite',
+              animation: 'apolos-tour-pulse 2.2s ease-in-out infinite',
               transition: 'top 350ms cubic-bezier(0.4, 0, 0.2, 1), left 350ms cubic-bezier(0.4, 0, 0.2, 1), width 350ms cubic-bezier(0.4, 0, 0.2, 1), height 350ms cubic-bezier(0.4, 0, 0.2, 1)',
             }}
           />
@@ -208,7 +208,7 @@ export function TutorialOverlay() {
               width: spotWidth,
               height: spotHeight,
               background: 'radial-gradient(ellipse at center, rgba(200,169,106,0.10) 0%, rgba(200,169,106,0) 70%)',
-              animation: 'tulia-tour-glow 2.6s ease-in-out infinite',
+              animation: 'apolos-tour-glow 2.6s ease-in-out infinite',
               transition: 'top 350ms cubic-bezier(0.4, 0, 0.2, 1), left 350ms cubic-bezier(0.4, 0, 0.2, 1), width 350ms cubic-bezier(0.4, 0, 0.2, 1), height 350ms cubic-bezier(0.4, 0, 0.2, 1)',
             }}
           />
@@ -223,7 +223,7 @@ export function TutorialOverlay() {
           width: TOOLTIP_W,
           top: tipTop,
           left: tipLeft,
-          animation: 'tulia-tour-fade-in 220ms ease-out',
+          animation: 'apolos-tour-fade-in 220ms ease-out',
         }}
       >
         <div className="flex items-center justify-between gap-2">

--- a/src/hooks/useAiDocuments.ts
+++ b/src/hooks/useAiDocuments.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * Reactive view of the study's attached AI context documents (extracted PDFs
- * shared as grounding context for Tulia). Backed by a Y.Array in the shared
+ * shared as grounding context for Apolos). Backed by a Y.Array in the shared
  * doc, so attachments and removals sync to every participant in real time.
  *
  * Returns empty state when used outside a study (no StudyDocContext provider),

--- a/src/lib/aiApi.ts
+++ b/src/lib/aiApi.ts
@@ -39,7 +39,7 @@ export interface AiCanvasContextEdge {
 }
 
 /**
- * Invoke the study assistant from the unified study chat ("/tulia ..."). The
+ * Invoke the study assistant from the unified study chat ("/apolos ..."). The
  * server builds the conversation context itself; the client sends the prompt
  * (mention already stripped is fine too), the linked conversation, and the
  * current canvas snapshot (which only the client can see).
@@ -79,7 +79,7 @@ export interface AiCanvasMutation {
 }
 
 export interface AiStudyChatResponse {
-  /** Tulia's reply, persisted as a real bot message in the conversation. */
+  /** Apolos's reply, persisted as a real bot message in the conversation. */
   message: ChatMessage
   mutations: AiCanvasMutation[]
   usage: AiUsageSummary

--- a/src/lib/chatApi.ts
+++ b/src/lib/chatApi.ts
@@ -38,7 +38,7 @@ export interface ChatMessage {
   conversation_id: number
   user_id:         number
   user:            ChatUser | null
-  /** True when sent by the "Tulia" AI assistant (rendered distinctly). */
+  /** True when sent by the "Apolos" AI assistant (rendered distinctly). */
   is_ai?:          boolean
   body:            string
   created_at:      string

--- a/src/lib/hooks/useSEOMeta.ts
+++ b/src/lib/hooks/useSEOMeta.ts
@@ -1,7 +1,7 @@
 import { useVerseStore } from '@/lib/store/useVerseStore'
 import { useUIStore } from '@/lib/store/useUIStore'
 
-const BASE_URL = 'https://bible.tulia.study'
+const BASE_URL = 'https://apolos.bible'
 const OG_IMAGE = `${BASE_URL}/logo.png`
 
 export interface SEOMetaData {
@@ -34,9 +34,9 @@ export function useSEOMeta(): SEOMetaData {
 
   let title: string
   if (verseNumber) {
-    title = `${bookName} ${selectedChapter}:${verseNumber} — Tulia Bible`
+    title = `${bookName} ${selectedChapter}:${verseNumber} — Apolos Bible`
   } else {
-    title = `${bookName} ${selectedChapter} — Tulia Bible`
+    title = `${bookName} ${selectedChapter} — Apolos Bible`
   }
 
   let description: string
@@ -45,7 +45,7 @@ export function useSEOMeta(): SEOMetaData {
   } else if (verses.length > 0 && verses[0]?.text) {
     description = `Read ${bookName} chapter ${selectedChapter}. ${verses[0].text.slice(0, 140).trim()}...`
   } else {
-    description = `Read ${bookName} chapter ${selectedChapter} in Tulia Bible, the collaborative Bible study app with cross-references, highlights, notes, and real-time study sessions.`
+    description = `Read ${bookName} chapter ${selectedChapter} in Apolos Bible, the collaborative Bible study app with cross-references, highlights, notes, and real-time study sessions.`
   }
 
   const langPrefix = locale && locale !== 'en' ? `${locale}/` : ''
@@ -58,7 +58,7 @@ export function useSEOMeta(): SEOMetaData {
   }
 
   const breadcrumbs = [
-    { name: 'Tulia Bible', url: BASE_URL },
+    { name: 'Apolos Bible', url: BASE_URL },
     { name: bookName, url: `${BASE_URL}/bible/${langPrefix}${selectedBook}` },
   ]
   if (verseNumber) {

--- a/src/lib/store/useChatStore.ts
+++ b/src/lib/store/useChatStore.ts
@@ -21,23 +21,23 @@ type ChatState = {
   loadingList:   boolean
   loadingThread: Record<number, boolean>
   typing:        Record<number, TypingEntry[]>
-  /** Per-conversation flag: Tulia (AI) is generating a reply right now. */
+  /** Per-conversation flag: Apolos (AI) is generating a reply right now. */
   aiThinking:    Record<number, boolean>
   /**
-   * Per-conversation composer audience. 'tulia' = sticky "Modo Tulia": every
-   * message is routed to the AI assistant without a "/tulia" prefix until the
+   * Per-conversation composer audience. 'apolos' = sticky "Modo Apolos": every
+   * message is routed to the AI assistant without a "/apolos" prefix until the
    * user exits. Default (absent) = 'study' (the human group). Local/UI only —
    * never synced to other participants.
    */
-  composerAudience: Record<number, 'study' | 'tulia'>
+  composerAudience: Record<number, 'study' | 'apolos'>
 
   load: () => Promise<void>
   select: (id: number | null) => Promise<void>
   loadMessages: (id: number) => Promise<void>
   loadOlder: (id: number) => Promise<void>
   send: (id: number, body: string) => Promise<void>
-  askTulia: (id: number, sessionId: string, prompt: string, documents?: AiContextDocument[]) => Promise<void>
-  setComposerAudience: (id: number, audience: 'study' | 'tulia') => void
+  askApolos: (id: number, sessionId: string, prompt: string, documents?: AiContextDocument[]) => Promise<void>
+  setComposerAudience: (id: number, audience: 'study' | 'apolos') => void
   markRead: (id: number) => Promise<void>
   notifyTyping: (id: number) => void
   listenForUpdates: (userId: number) => void
@@ -123,7 +123,7 @@ function subscribeToConversation(id: number, set: (fn: (s: ChatState) => Partial
         // Desktop tray: render an OS banner via tauri-plugin-notification.
         // Web/SW path is handled by FCM data-only pushes; backend skips
         // FCM when the user is online so this won't double up.
-        const senderName = message.user?.name || 'Tulia'
+        const senderName = message.user?.name || 'Apolos'
         void notifyChatMessage(id, senderName, message.body)
       }
     })
@@ -254,11 +254,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     })
   },
 
-  // Invoke the Tulia AI assistant for a study conversation. The human "/tulia"
+  // Invoke the Apolos AI assistant for a study conversation. The human "/apolos"
   // message has already been sent; this runs the grounded loop server-side,
-  // appends Tulia's persisted reply, and applies any canvas mutations. Other
+  // appends Apolos's persisted reply, and applies any canvas mutations. Other
   // participants receive the reply over the normal realtime channel.
-  askTulia: async (id, sessionId, prompt, documents) => {
+  askApolos: async (id, sessionId, prompt, documents) => {
     set((s) => ({ aiThinking: { ...s.aiThinking, [id]: true } }))
     try {
       const actions = (window as never as { __studyCanvasActions?: {
@@ -292,7 +292,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 last_message: {
                   id:         message.id,
                   user_id:    message.user_id,
-                  user_name:  message.user?.name ?? 'Tulia',
+                  user_name:  message.user?.name ?? 'Apolos',
                   body:       message.body,
                   created_at: message.created_at,
                 },
@@ -310,10 +310,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const status = (e as { status?: number } | null)?.status
       const msg =
         status === 403
-          ? i18n.t('study.ai.errorVerify', 'Verifica tu correo para usar a Tulia.')
+          ? i18n.t('study.ai.errorVerify', 'Verifica tu correo para usar a Apolos.')
           : status === 429
             ? i18n.t('study.ai.errorBudget', 'Has alcanzado el límite de IA de este mes.')
-            : i18n.t('study.ai.errorGeneric', 'No se pudo contactar a Tulia. Intenta de nuevo.')
+            : i18n.t('study.ai.errorGeneric', 'No se pudo contactar a Apolos. Intenta de nuevo.')
       useUIStore.getState().addToast(msg, 'error')
     } finally {
       set((s) => ({ aiThinking: { ...s.aiThinking, [id]: false } }))

--- a/src/lib/study/yDocHelpers.ts
+++ b/src/lib/study/yDocHelpers.ts
@@ -9,9 +9,9 @@ export function getEdgesMap(doc: Y.Doc): Y.Map<Y.Map<any>> {
 }
 
 // --- Attached AI context documents (shared across all study participants) ---
-// Extracted text of PDFs a participant shared as grounding context for Tulia.
+// Extracted text of PDFs a participant shared as grounding context for Apolos.
 // They live in the Yjs doc so everyone sees the same attachments and anyone's
-// "/tulia" question carries them. They are NEVER auto-added to the canvas.
+// "/apolos" question carries them. They are NEVER auto-added to the canvas.
 export interface StoredAiDocument {
   id: string;
   name: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -43,7 +43,7 @@
   "sidebar.newTestament": "New Testament",
 
   "auth.signIn": "Sign in",
-  "auth.signInTitle": "Sign in to Tulia",
+  "auth.signInTitle": "Sign in to Apolos",
   "auth.welcomeBack": "Welcome back.",
   "auth.createAccount": "Create account",
   "auth.startJourney": "Start your study journey.",
@@ -149,9 +149,9 @@
   "study.toolbar.unlock": "Unlock",
   "study.toolbar.chat": "Chat (A)",
 
-  "study.ai.errorVerify": "Verify your email to use Tulia.",
+  "study.ai.errorVerify": "Verify your email to use Apolos.",
   "study.ai.errorBudget": "You've reached this month's AI limit.",
-  "study.ai.errorGeneric": "Couldn't reach Tulia. Try again.",
+  "study.ai.errorGeneric": "Couldn't reach Apolos. Try again.",
 
   "study.node.delete": "Delete",
   "study.node.duplicate": "Duplicate",
@@ -163,12 +163,12 @@
   "study.chat.toggle": "Toggle study chat",
   "study.chat.close": "Close",
   "study.chat.minimize": "Minimize",
-  "study.chat.tuliaMode": "Tulia mode",
-  "study.chat.toTulia": "Ask Tulia…",
-  "study.chat.sendToTulia": "Send to Tulia",
-  "study.chat.exitTulia": "Exit Tulia mode (Esc)",
-  "study.chat.continueTulia": "Continue with Tulia",
-  "study.chat.returnNudge": "Back to the study? You're still messaging Tulia.",
+  "study.chat.apolosMode": "Apolos mode",
+  "study.chat.toApolos": "Ask Apolos…",
+  "study.chat.sendToApolos": "Send to Apolos",
+  "study.chat.exitApolos": "Exit Apolos mode (Esc)",
+  "study.chat.continueApolos": "Continue with Apolos",
+  "study.chat.returnNudge": "Back to the study? You're still messaging Apolos.",
 
   "study.topBar.exit": "Exit",
   "study.topBar.invite": "Invite",
@@ -400,7 +400,7 @@
   "chat.commandInsert": "↵ insert",
   "chat.commandClose": "Esc close",
   "chat.commandVerseDesc": "Search and insert a verse",
-  "chat.commandTuliaDesc": "Talk to Tulia (the AI)",
+  "chat.commandApolosDesc": "Talk to Apolos (the AI)",
   "chat.conversationsEmpty": "No conversations yet. Start one from the + button.",
   "chat.empty.headline": "No conversation yet",
   "chat.empty.body": "Invite a friend or join a study to start chatting.",
@@ -503,7 +503,7 @@
   "updater.failed": "Could not install update",
 
   "tutorial.invite.title": "Quick tour?",
-  "tutorial.invite.body": "We'll walk you through Tulia's main features in under a minute.",
+  "tutorial.invite.body": "We'll walk you through Apolos's main features in under a minute.",
   "tutorial.invite.start": "Start",
   "tutorial.invite.skip": "Not now",
 
@@ -513,7 +513,7 @@
   "tutorial.done": "Done",
   "tutorial.stepCount": "Step {{current}} of {{total}}",
 
-  "tutorial.welcome.title": "Welcome to Tulia",
+  "tutorial.welcome.title": "Welcome to Apolos",
   "tutorial.welcome.body": "A social, minimalist way to read the Bible with friends. We'll show you the essentials — you can skip anytime (Esc).",
 
   "tutorial.logo.title": "Your home",
@@ -553,7 +553,7 @@
   "tutorial.toolbar.body": "Chapter commentary, version comparison, and cross-references — all from this bar.",
 
   "tutorial.shortcuts.title": "Keyboard shortcuts",
-  "tutorial.shortcuts.body": "Tulia is keyboard-first: J/K for verses, ←/→ for chapters, {{modKey}}K to search, ? to see all shortcuts.",
+  "tutorial.shortcuts.body": "Apolos is keyboard-first: J/K for verses, ←/→ for chapters, {{modKey}}K to search, ? to see all shortcuts.",
 
   "tutorial.done.title": "You're set",
   "tutorial.done.body": "That's the gist. Press ? any time to see shortcuts. Enjoy your reading.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -43,7 +43,7 @@
   "sidebar.newTestament": "Nuevo Testamento",
 
   "auth.signIn": "Iniciar sesión",
-  "auth.signInTitle": "Inicia sesión en Tulia",
+  "auth.signInTitle": "Inicia sesión en Apolos",
   "auth.welcomeBack": "Bienvenido de nuevo.",
   "auth.createAccount": "Crear cuenta",
   "auth.startJourney": "Empieza tu jornada de estudio.",
@@ -149,9 +149,9 @@
   "study.toolbar.unlock": "Desbloquear",
   "study.toolbar.chat": "Chat (A)",
 
-  "study.ai.errorVerify": "Verifica tu correo para usar a Tulia.",
+  "study.ai.errorVerify": "Verifica tu correo para usar a Apolos.",
   "study.ai.errorBudget": "Has alcanzado el límite de IA de este mes.",
-  "study.ai.errorGeneric": "No se pudo contactar a Tulia. Intenta de nuevo.",
+  "study.ai.errorGeneric": "No se pudo contactar a Apolos. Intenta de nuevo.",
 
   "study.node.delete": "Eliminar",
   "study.node.duplicate": "Duplicar",
@@ -163,12 +163,12 @@
   "study.chat.toggle": "Mostrar chat del estudio",
   "study.chat.close": "Cerrar",
   "study.chat.minimize": "Minimizar",
-  "study.chat.tuliaMode": "Modo Tulia",
-  "study.chat.toTulia": "Pregúntale a Tulia…",
-  "study.chat.sendToTulia": "Enviar a Tulia",
-  "study.chat.exitTulia": "Salir del modo Tulia (Esc)",
-  "study.chat.continueTulia": "Seguir con Tulia",
-  "study.chat.returnNudge": "¿Volver al estudio? Sigues escribiéndole a Tulia.",
+  "study.chat.apolosMode": "Modo Apolos",
+  "study.chat.toApolos": "Pregúntale a Apolos…",
+  "study.chat.sendToApolos": "Enviar a Apolos",
+  "study.chat.exitApolos": "Salir del modo Apolos (Esc)",
+  "study.chat.continueApolos": "Seguir con Apolos",
+  "study.chat.returnNudge": "¿Volver al estudio? Sigues escribiéndole a Apolos.",
 
   "study.topBar.exit": "Salir",
   "study.topBar.invite": "Invitar",
@@ -400,7 +400,7 @@
   "chat.commandInsert": "↵ insertar",
   "chat.commandClose": "Esc cerrar",
   "chat.commandVerseDesc": "Buscar e insertar un versículo",
-  "chat.commandTuliaDesc": "Hablar con Tulia (la IA)",
+  "chat.commandApolosDesc": "Hablar con Apolos (la IA)",
   "chat.conversationsEmpty": "Sin conversaciones aún. Inicia una desde el botón +.",
   "chat.empty.headline": "Aún no hay tertulia",
   "chat.empty.body": "Invita a un amigo o únete a un estudio para empezar a conversar.",
@@ -503,7 +503,7 @@
   "updater.failed": "No se pudo instalar la actualización",
 
   "tutorial.invite.title": "¿Tour rápido?",
-  "tutorial.invite.body": "Te mostramos las funciones principales de Tulia en menos de un minuto.",
+  "tutorial.invite.body": "Te mostramos las funciones principales de Apolos en menos de un minuto.",
   "tutorial.invite.start": "Empezar",
   "tutorial.invite.skip": "Ahora no",
 
@@ -513,7 +513,7 @@
   "tutorial.done": "Listo",
   "tutorial.stepCount": "Paso {{current}} de {{total}}",
 
-  "tutorial.welcome.title": "Bienvenido a Tulia",
+  "tutorial.welcome.title": "Bienvenido a Apolos",
   "tutorial.welcome.body": "Una forma social y minimalista de leer la Biblia con amigos. Te mostraremos lo esencial — puedes saltar en cualquier momento (Esc).",
 
   "tutorial.logo.title": "Tu inicio",
@@ -553,7 +553,7 @@
   "tutorial.toolbar.body": "Comentario del capítulo, comparar versiones y referencias cruzadas — todo desde esta barra.",
 
   "tutorial.shortcuts.title": "Atajos de teclado",
-  "tutorial.shortcuts.body": "Tulia es primero teclado: J/K para versículos, ←/→ para capítulos, {{modKey}}K para buscar, ? para ver todos los atajos.",
+  "tutorial.shortcuts.body": "Apolos es primero teclado: J/K para versículos, ←/→ para capítulos, {{modKey}}K para buscar, ? para ver todos los atajos.",
 
   "tutorial.done.title": "¡Todo listo!",
   "tutorial.done.body": "Eso es lo esencial. Pulsa ? cuando quieras ver los atajos. Disfruta tu lectura.",

--- a/src/router/routes/AuthBridgeRoute.tsx
+++ b/src/router/routes/AuthBridgeRoute.tsx
@@ -25,7 +25,7 @@ export function AuthBridgeRoute() {
   }, [error])
 
   useEffect(() => {
-    document.title = 'Tulia'
+    document.title = 'Apolos'
   }, [])
 
   const open = () => {
@@ -48,14 +48,14 @@ export function AuthBridgeRoute() {
               {t('authBridge.errorTitle', 'No pudimos completar el inicio de sesión')}
             </h1>
             <p className="text-sm text-text-muted mb-6">
-              {t('authBridge.errorBody', 'Vuelve a Tulia e inténtalo otra vez.')}
+              {t('authBridge.errorBody', 'Vuelve a Apolos e inténtalo otra vez.')}
             </p>
             <button
               type="button"
               onClick={open}
               className="w-full py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors"
             >
-              {t('authBridge.returnToApp', 'Volver a Tulia')}
+              {t('authBridge.returnToApp', 'Volver a Apolos')}
             </button>
           </>
         ) : (
@@ -66,7 +66,7 @@ export function AuthBridgeRoute() {
             <p className="text-sm text-text-muted mb-6">
               {t(
                 'authBridge.readyBody',
-                'Toca el botón para volver a la app de Tulia y terminar de iniciar sesión.',
+                'Toca el botón para volver a la app de Apolos y terminar de iniciar sesión.',
               )}
             </p>
             <button
@@ -75,14 +75,14 @@ export function AuthBridgeRoute() {
               className="w-full py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors"
             >
               {launched
-                ? t('authBridge.opening', 'Abriendo Tulia…')
-                : t('authBridge.openApp', 'Abrir en Tulia')}
+                ? t('authBridge.opening', 'Abriendo Apolos…')
+                : t('authBridge.openApp', 'Abrir en Apolos')}
             </button>
             {launched && (
               <p className="mt-4 text-xs text-text-muted">
                 {t(
                   'authBridge.fallback',
-                  '¿No se abrió la app? Asegúrate de tener Tulia instalada y vuelve a tocar el botón.',
+                  '¿No se abrió la app? Asegúrate de tener Apolos instalada y vuelve a tocar el botón.',
                 )}
               </p>
             )}


### PR DESCRIPTION
## Resumen

Renombrado de marca **Tulia → Apolos** en todo el frontend. El nombre viene de **Apolos** (Hechos 18:24-28) — judío de Alejandría, *"poderoso en las Escrituras"*, instruido con más exactitud por Priscila y Aquila. El asistente de IA dentro de la app también pasa a llamarse Apolos ("estudia con Apolos").

Dominios: web app `apolos.bible` (Firebase Hosting), API/landing `apolos.io`. Los dominios antiguos `tulia.study` / `bible.tulia.study` quedan como alias de transición.

## Qué se renombró

- **Marca y dominios visibles**: `index.html` (title/meta/OG/JSON-LD), `SEOMeta.tsx`, `useSEOMeta.ts`, `robots.txt` (sitemap → `https://apolos.bible/...`), generador de capítulos estáticos, wordmark de `Logo.tsx` (`apolos.bible`), fallbacks de notificación del service worker FCM.
- **package.json**: `"name": "tulia-study"` → `"apolos"`.
- **Asistente de IA (ahora Apolos)**: comando de chat `/tulia` → `/apolos`; "Modo Tulia" → "Modo Apolos"; textos y claves i18n (`study.chat.apolosMode`, `toApolos`, `sendToApolos`, `exitApolos`, `continueApolos`, `chat.commandApolosDesc`) en `es.json` y `en.json` (paridad de claves verificada: 621/621); valor interno de audiencia del composer `'tulia'` → `'apolos'`; acción del store `askTulia` → `askApolos`; identificadores internos (`TULIA_PREFIX`→`APOLOS_PREFIX`, `onContinueWithTulia`→`onContinueWithApolos`, `tuliaArmed`→`apolosArmed`, ganchos del tour `apolos-tour-*` / `window.apolosTour`); etiqueta del remitente bot `'Tulia'` → `'Apolos'`.
- **Tauri**: `productName` y título de ventana → `Apolos`; menú de bandeja "Open Apolos".
- **Android**: `app_name` / `main_activity_title` → `Apolos`; fallback del título de notificación FCM → `Apolos`.
- **Release**: nombres de artefactos → `Apolos_<version>.apk/.aab` (`rename-android-build.mjs`).
- **Docs**: `README.md`, `CLAUDE.md`, `AGENTS.md` — marca, origen del nombre (Apolos, Hechos 18:24-28, enseñado por Priscila y Aquila), dominios y nombre del paquete. Contenido técnico intacto.

**33 archivos modificados.**

## Conservado a propósito (no tocar — identidad / infraestructura)

| Elemento | Dónde | Motivo |
|---|---|---|
| `tulia-bible`, `tulia-push` | `.firebaserc`, `firebase-messaging-sw.js`, `release.yml` (`projectId`) | IDs de proyecto/sitio de Firebase + `messagingSenderId`/`appId` |
| Bundle id `study.tulia.bible` | `tauri.conf.json` (`identifier`), `build.gradle.kts` (`namespace`/`applicationId`), `release.yml` (`packageName`) | Cambiarlo rompe actualizaciones de la app y los datos locales |
| Ruta de paquete Java `study/tulia/bible` + declaraciones `package` | `MainActivity.kt`, `TuliaMessagingService.kt` | Identidad del paquete Android |
| Esquema deep-link `tulia://` | `AndroidManifest.xml`, `tauri.conf.json` (schemes), `deepLink.ts`, `AuthBridgeRoute.tsx` | Contrato del redirect OAuth registrado en el SO (el backend envía `tulia://auth/finish`) |
| Contratos nativo↔web | evento `tulia-navigate`, extras `tulia_url`/`tulia_conversation_id`, `__TULIA_FCM_TOKEN__`, canal `tulia_chat`, prefs `tulia_fcm`, clave localStorage `tulia_version_id` | Romperían IPC, notificaciones o preferencias guardadas de usuarios |
| Clase `TuliaMessagingService` | `gen/android/.../TuliaMessagingService.kt` | Generado por Tauri y referenciado por el manifest; solo se actualizó el texto visible (ver nota abajo) |
| URLs del repo `Tulia-Study/tulia-bible` | `tauri.conf.json` (updater), docs, `release.yml` | Org/repo de GitHub |
| `.env.production` / `.env.local` | — | Ya migrado / local |

## Nota sobre el comando `/tulia` → `/apolos`

El comando `/apolos` requiere que el **PR de rename del backend esté desplegado primero**. El backend mantendrá compatibilidad hacia atrás (seguirá aceptando `/tulia`) durante la transición.

## Verificación

- `pnpm build:web` ✅ (compila; banner muestra `apolos@0.4.0`).
- `pnpm test` ✅ para todo lo relacionado: 187 pasan. Quedan **3 fallos preexistentes** en `usePresenceStore.test.ts` (canales de presencia `chapter.*`), confirmados también en `origin/main` limpio — **no** los introduce este PR y no tocan branding.

## Decisiones de criterio

- **Clase `TuliaMessagingService` sin renombrar**: el prompt permitía renombrarla a `ApolosMessagingService` solo si se actualizaba el manifest de forma consistente. Al ser un archivo **generado por Tauri** bajo `gen/android/` y un identificador no visible para el usuario, opté por la ruta documentada de menor riesgo (actualizar solo el texto visible: fallback de título `"Tulia"` → `"Apolos"`), evitando tocar el registro del servicio en el manifest y la identidad del paquete.
- **`"tertulia"` conservado** en `chat.empty.headline` ("Aún no hay tertulia"): es un sustantivo común en español (la reunión para conversar), no la marca — es justamente el juego de palabras original.
- **Claves i18n renombradas** (`toTulia`→`toApolos`, etc.) además de los valores, manteniendo todos los call sites `t()` actualizados, para no dejar claves con marca vieja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)